### PR TITLE
fix crash loading turbine

### DIFF
--- a/src/main/java/mekanism/api/Coord4D.java
+++ b/src/main/java/mekanism/api/Coord4D.java
@@ -1,5 +1,7 @@
 package mekanism.api;
 
+import javax.annotation.Nullable;
+
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import mekanism.common.base.TileNetworkList;
@@ -125,6 +127,7 @@ public class Coord4D {
      * @param world - world this Coord4D is in
      * @return the TileEntity of this Coord4D's block
      */
+    @Nullable
     public TileEntity getTileEntity(IBlockAccess world) {
         if (world instanceof World && !exists((World) world)) {
             return null;
@@ -139,6 +142,7 @@ public class Coord4D {
      * @param world - world this Coord4D is in
      * @return the Block value of this Coord4D's block
      */
+    @Nullable
     public Block getBlock(IBlockAccess world) {
         if (world instanceof World && !exists((World) world)) {
             return null;
@@ -269,6 +273,7 @@ public class Coord4D {
      * @param other - Coord4D to find the side difference of
      * @return EnumFacing representing the side the defined relative Coord4D is on to this
      */
+    @Nullable
     public EnumFacing sideDifference(Coord4D other) {
         Coord4D diff = difference(other);
 

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
@@ -77,7 +77,7 @@ public class TileEntityTurbineRotor extends TileEntityBasicBlock {
                 newBlades += ((TileEntityTurbineRotor) rotorTe).getHousedBlades();
             }
 
-            pointer.offset(EnumFacing.UP);
+            pointer = pointer.offset(EnumFacing.UP);
         }
 
         TileEntity teRotationalComplex = pointer.getTileEntity(world);


### PR DESCRIPTION
This should close #15. Teleporting around in a test world the turbine seemed to reform correctly when reloading chunks but you may want to test for yourself. 

I'm pretty sure adding the `Nullable` annotations to the api doesn't break compatibility but I could be wrong there.