### PR TITLE
use oredict in mekanism tools

### DIFF
--- a/src/main/resources/assets/mekanismtools/recipes/_constants.json
+++ b/src/main/resources/assets/mekanismtools/recipes/_constants.json
@@ -7,42 +7,42 @@
     }
   },
   {
-    "name": "INGOTBRONZE",
+    "name": "INGOT_BRONZE",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotBronze"
     }
   },
   {
-    "name": "INGOTIRON",
+    "name": "INGOT_IRON",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotIron"
     }
   },
   {
-    "name": "INGOTSTEEL",
+    "name": "INGOT_STEEL",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotSteel"
     }
   },
   {
-    "name": "INGOTOSMIUM",
+    "name": "INGOT_OSMIUM",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotOsmium"
     }
   },
   {
-    "name": "INGOTREFINEDGLOWSTONE",
+    "name": "INGOT_REFINED_GLOWSTONE",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotRefinedGlowstone"
     }
   },
   {
-    "name": "INGOTREFINEDOBSIDIAN",
+    "name": "INGOT_REFINED_OBSIDIAN",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "ingotRefinedObsidian"

--- a/src/main/resources/assets/mekanismtools/recipes/_constants.json
+++ b/src/main/resources/assets/mekanismtools/recipes/_constants.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "STICKWOOD",
+    "name": "STICK_WOOD",
     "ingredient": {
       "type": "forge:ore_dict",
       "ore": "stickWood"
@@ -49,11 +49,10 @@
     }
   },
   {
-    "name": "GEMLAPIS",
+    "name": "GEM_LAPIS",
     "ingredient": {
-      "item": "minecraft:dye",
-      "data": 4,
-      "__comment": "using oredict is probably risky here"
+      "type": "forge:ore_dict",
+      "ore": "gemLapis"
     }
   }
 ]

--- a/src/main/resources/assets/mekanismtools/recipes/_constants.json
+++ b/src/main/resources/assets/mekanismtools/recipes/_constants.json
@@ -1,0 +1,59 @@
+[
+  {
+    "name": "STICKWOOD",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "stickWood"
+    }
+  },
+  {
+    "name": "INGOTBRONZE",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotBronze"
+    }
+  },
+  {
+    "name": "INGOTIRON",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotIron"
+    }
+  },
+  {
+    "name": "INGOTSTEEL",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotSteel"
+    }
+  },
+  {
+    "name": "INGOTOSMIUM",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotOsmium"
+    }
+  },
+  {
+    "name": "INGOTREFINEDGLOWSTONE",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotRefinedGlowstone"
+    }
+  },
+  {
+    "name": "INGOTREFINEDOBSIDIAN",
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "ingotRefinedObsidian"
+    }
+  },
+  {
+    "name": "GEMLAPIS",
+    "ingredient": {
+      "item": "minecraft:dye",
+      "data": 4,
+      "__comment": "using oredict is probably risky here"
+    }
+  }
+]

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_BRONZE"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeboots.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeboots.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzechestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzechestplate.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzechestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzechestplate.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzehelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzehelmet.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzehelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzehelmet.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzehoe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_BRONZE"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeleggings.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeleggings.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "mekanismtools:bronzeaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "mekanismtools:bronzeaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzepickaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_BRONZE"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzeshovel.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_BRONZE"

--- a/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotBronze",
-      "type": "forge:ore_dict"
+      "item": "#INGOTBRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTBRONZE"
+      "item": "#INGOT_BRONZE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/bronzesword.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_BRONZE"

--- a/src/main/resources/assets/mekanismtools/recipes/diamondpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/diamondpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "minecraft:diamond_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/diamondpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/diamondpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "minecraft:diamond_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_GLOWSTONE"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneboots.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneboots.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonechestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonechestplate.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonechestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonechestplate.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonehelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonehelmet.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonehelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonehelmet.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_GLOWSTONE"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonehoe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneleggings.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneleggings.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "mekanismtools:glowstoneaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "mekanismtools:glowstoneaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_GLOWSTONE"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonepickaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_GLOWSTONE"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstoneshovel.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_GLOWSTONE"

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedGlowstone",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDGLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/glowstonesword.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDGLOWSTONE"
+      "item": "#INGOT_REFINED_GLOWSTONE"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/goldpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/goldpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "minecraft:golden_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/goldpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/goldpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "minecraft:golden_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/ironpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/ironpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "minecraft:iron_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/ironpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/ironpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "minecraft:iron_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazuliaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazuliaxe.json
@@ -10,11 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazuliaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazuliaxe.json
@@ -10,10 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazuliboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazuliboots.json
@@ -9,8 +9,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazuliboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazuliboots.json
@@ -9,7 +9,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulichestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulichestplate.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulichestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulichestplate.json
@@ -10,8 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulihelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulihelmet.json
@@ -9,8 +9,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulihelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulihelmet.json
@@ -9,7 +9,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulihoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulihoe.json
@@ -10,11 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulihoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulihoe.json
@@ -10,10 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulileggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulileggings.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulileggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulileggings.json
@@ -10,8 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "*": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulipaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulipaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "mekanismtools:lapislazuliaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulipaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulipaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "mekanismtools:lapislazuliaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulipickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulipickaxe.json
@@ -10,11 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulipickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulipickaxe.json
@@ -10,10 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulishovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulishovel.json
@@ -10,11 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulishovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulishovel.json
@@ -10,10 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulisword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulisword.json
@@ -10,11 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "item": "minecraft:dye",
-      "data": 4
+      "item": "#GEMLAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/lapislazulisword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/lapislazulisword.json
@@ -10,10 +10,10 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
-      "item": "#GEMLAPIS"
+      "item": "#GEM_LAPIS"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_OBSIDIAN"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianboots.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianboots.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianchestplate.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianchestplate.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianhelmet.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianhelmet.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_OBSIDIAN"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianhoe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianleggings.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianleggings.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "mekanismtools:obsidianaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "mekanismtools:obsidianaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_OBSIDIAN"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianpickaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_OBSIDIAN"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidianshovel.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTREFINEDOBSIDIAN"
+      "item": "#INGOT_REFINED_OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_REFINED_OBSIDIAN"

--- a/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/obsidiansword.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotRefinedObsidian",
-      "type": "forge:ore_dict"
+      "item": "#INGOTREFINEDOBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_OSMIUM"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumboots.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumboots.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumchestplate.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumchestplate.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumhelmet.json
@@ -9,7 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumhelmet.json
@@ -9,8 +9,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_OSMIUM"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumhoe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumleggings.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumleggings.json
@@ -10,8 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "*": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "mekanismtools:osmiumaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "mekanismtools:osmiumaxe"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_OSMIUM"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumpickaxe.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_OSMIUM"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumshovel.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
-      "ore": "ingotOsmium",
-      "type": "forge:ore_dict"
+      "item": "#INGOTOSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
@@ -10,7 +10,7 @@
   "type": "forge:ore_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "#INGOT_OSMIUM"

--- a/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/osmiumsword.json
@@ -13,7 +13,7 @@
       "item": "#STICKWOOD"
     },
     "X": {
-      "item": "#INGOTOSMIUM"
+      "item": "#INGOT_OSMIUM"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelaxe.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelboots.json
@@ -9,11 +9,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     },
     "*": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelboots.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelboots.json
@@ -9,10 +9,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     },
     "*": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelchestplate.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     },
     "*": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelchestplate.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelchestplate.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     },
     "*": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelhelmet.json
@@ -9,11 +9,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     },
     "*": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelhelmet.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelhelmet.json
@@ -9,10 +9,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     },
     "*": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelhoe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelhoe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelhoe.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelleggings.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     },
     "*": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelleggings.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelleggings.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     },
     "*": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelpaxel.json
@@ -16,7 +16,7 @@
       "item": "mekanismtools:steelpickaxe"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     },
     "Z": {
       "item": "mekanismtools:steelshovel"

--- a/src/main/resources/assets/mekanismtools/recipes/steelpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelpaxel.json
@@ -16,7 +16,7 @@
       "item": "mekanismtools:steelpickaxe"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     },
     "Z": {
       "item": "mekanismtools:steelshovel"

--- a/src/main/resources/assets/mekanismtools/recipes/steelpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelpickaxe.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelpickaxe.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelpickaxe.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelshovel.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelshovel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelshovel.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelsword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelsword.json
@@ -10,11 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "ore": "ingotSteel",
-      "type": "forge:ore_dict"
+      "item": "#INGOTSTEEL"
     },
     "I": {
-      "item": "minecraft:iron_ingot"
+      "item": "#INGOTIRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/steelsword.json
+++ b/src/main/resources/assets/mekanismtools/recipes/steelsword.json
@@ -10,10 +10,10 @@
   "type": "forge:ore_shaped",
   "key": {
     "X": {
-      "item": "#INGOTSTEEL"
+      "item": "#INGOT_STEEL"
     },
     "I": {
-      "item": "#INGOTIRON"
+      "item": "#INGOT_IRON"
     }
   }
 }

--- a/src/main/resources/assets/mekanismtools/recipes/stonepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/stonepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "minecraft:stone_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/stonepaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/stonepaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "minecraft:stone_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/woodpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/woodpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "#STICKWOOD"
+      "item": "#STICK_WOOD"
     },
     "X": {
       "item": "minecraft:wooden_axe"

--- a/src/main/resources/assets/mekanismtools/recipes/woodpaxel.json
+++ b/src/main/resources/assets/mekanismtools/recipes/woodpaxel.json
@@ -10,7 +10,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "T": {
-      "item": "minecraft:stick"
+      "item": "#STICKWOOD"
     },
     "X": {
       "item": "minecraft:wooden_axe"


### PR DESCRIPTION
It would probably be good to move things commonly oredicted to `_constants` in generators and mekanism too.