### PR TITLE
null check FluidStack in turbine vent

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -79,7 +79,7 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
 
     @Override
     public boolean canDrain(EnumFacing from, FluidStack fluid) {
-        return fluid.getFluid().equals(FluidRegistry.WATER);
+        return fluid != null && fluid.getFluid().equals(FluidRegistry.WATER);
     }
 
     @Override


### PR DESCRIPTION
Seems like this is just a missing null check. Sadly there doesn't seem to be anything like `ItemStack.EMPTY` for fluids.