### PR TITLE
fix crash in SoundHandler

### DIFF
--- a/src/main/java/mekanism/client/sound/SoundHandler.java
+++ b/src/main/java/mekanism/client/sound/SoundHandler.java
@@ -145,6 +145,7 @@ public class SoundHandler {
         // At this point, we've got a known block Mekanism sound. We want to re-wrap the original
         // using the (possibly) muffled sound as the initial volume. The TileSound will then periodically poll
         // to see if the volume should be adjusted
+        resultSound.createAccessor(Minecraft.getMinecraft().getSoundHandler()); //this means the sound isn't null
         resultSound = new TileSound(event.getSound(), resultSound.getVolume());
         event.setResultSound(resultSound);
 


### PR DESCRIPTION
This call is necessary to make sure the `sound` in `PlaySoundEvent` isn't `null`. Could potentially fix sounds on other machines as well.