### PR TITLE
Remove dependence on MTLib for CraftTweaker Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,6 @@ dependencies {
     deobfCompile ("CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-${config.crafttweaker_version}") {
         exclude module: "asm-debug-all"
     }
-    compileOnly "com.blamejared:MTLib:${config.mtlib_version}"
     compileOnly "dan200.computercraft:ComputerCraft:${config.computercraft_version}:api"
     compileOnly "mcjty.theoneprobe:TheOneProbe-1.12:${config.top_version}:api"
     compileOnly "appeng:appliedenergistics2:${config.ae2_version}:api"

--- a/build.properties
+++ b/build.properties
@@ -12,7 +12,6 @@ buildcraft_version=7.99.12
 ctm_version=0.2.1.5
 ic2_version=2.8.9-ex112
 crafttweaker_version=4.1.15.527
-mtlib_version=3.0.1.3
 computercraft_version=1.80pr1
 top_version=1.12-1.4.19-11
 ae2_version=rv5-stable-11

--- a/src/main/java/mekanism/common/integration/crafttweaker/commands/MekRecipesCommand.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/commands/MekRecipesCommand.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.commands;
 
-import com.blamejared.mtlib.helpers.LogHelper;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.mc1120.commands.CraftTweakerCommand;
 import crafttweaker.mc1120.commands.SpecialMessagesChat;
@@ -75,7 +74,7 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                         CraftTweakerAPI
                               .logCommand(String.format("mods.mekanism.chemical.crystallizer.addRecipe(%s, %s)",
                                     RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
-                                    LogHelper.getStackDescription(recipe.getOutput().output)
+                                    RecipeInfoHelper.getItemName(recipe.getOutput().output)
                               ));
                     }
                 }
@@ -86,7 +85,7 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof DissolutionRecipe) {
                         DissolutionRecipe recipe = (DissolutionRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.dissolution.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
                               RecipeInfoHelper.getGasName(recipe.getOutput().output)
                         ));
                     }
@@ -112,9 +111,9 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                         InjectionRecipe recipe = (InjectionRecipe) value;
                         CraftTweakerAPI
                               .logCommand(String.format("mods.mekanism.chemical.injection.addRecipe(%s, %s, %s)",
-                                    LogHelper.getStackDescription(recipe.getInput().itemStack),
+                                    RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
                                     RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                                    LogHelper.getStackDescription(recipe.getOutput().output)
+                                    RecipeInfoHelper.getItemName(recipe.getOutput().output)
                               ));
                     }
                 }
@@ -125,7 +124,7 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof OxidationRecipe) {
                         OxidationRecipe recipe = (OxidationRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.oxidizer.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
                               RecipeInfoHelper.getGasName(recipe.getOutput().output)
                         ));
                     }
@@ -149,9 +148,9 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof CombinerRecipe) {
                         CombinerRecipe recipe = (CombinerRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.combiner.addRecipe(%s, %s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().itemStack),
-                              LogHelper.getStackDescription(recipe.getInput().extraStack),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
+                              RecipeInfoHelper.getItemName(recipe.getInput().extraStack),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -162,8 +161,8 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof CrusherRecipe) {
                         CrusherRecipe recipe = (CrusherRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.crusher.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -174,7 +173,7 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof SeparatorRecipe) {
                         SeparatorRecipe recipe = (SeparatorRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.separator.addRecipe(%s, %s, %s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
                               recipe.energyUsage,
                               RecipeInfoHelper.getGasName(recipe.getOutput().leftGas),
                               RecipeInfoHelper.getGasName(recipe.getOutput().rightGas)
@@ -188,8 +187,8 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof SmeltingRecipe) {
                         SmeltingRecipe recipe = (SmeltingRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.smelter.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -200,8 +199,8 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof EnrichmentRecipe) {
                         EnrichmentRecipe recipe = (EnrichmentRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.enrichment.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -214,8 +213,8 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.infuser.addRecipe(%s, %s, %s, %s)",
                               recipe.getInput().infuse.type,
                               recipe.getInput().infuse.amount,
-                              LogHelper.getStackDescription(recipe.getInput().inputStack),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getInput().inputStack),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -226,9 +225,9 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof OsmiumCompressorRecipe) {
                         OsmiumCompressorRecipe recipe = (OsmiumCompressorRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.compressor.addRecipe(%s, %s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().itemStack),
+                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
                               RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -239,9 +238,9 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof SawmillRecipe) {
                         SawmillRecipe recipe = (SawmillRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.sawmill.addRecipe(%s, %s, %s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
-                              LogHelper.getStackDescription(recipe.getOutput().primaryOutput),
-                              LogHelper.getStackDescription(recipe.getOutput().secondaryOutput),
+                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().primaryOutput),
+                              RecipeInfoHelper.getItemName(recipe.getOutput().secondaryOutput),
                               recipe.getOutput().secondaryChance
                         ));
                     }
@@ -254,10 +253,10 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                         PressurizedRecipe recipe = (PressurizedRecipe) value;
                         CraftTweakerAPI
                               .logCommand(String.format("mods.mekanism.reaction.addRecipe(%s, %s, %s, %s, %s, %s, %s)",
-                                    LogHelper.getStackDescription(recipe.getInput().getSolid()),
-                                    LogHelper.getStackDescription(recipe.getInput().getFluid()),
+                                    RecipeInfoHelper.getItemName(recipe.getInput().getSolid()),
+                                    RecipeInfoHelper.getFluidName(recipe.getInput().getFluid()),
                                     RecipeInfoHelper.getGasName(recipe.getInput().getGas()),
-                                    LogHelper.getStackDescription(recipe.getOutput().getItemOutput()),
+                                    RecipeInfoHelper.getItemName(recipe.getOutput().getItemOutput()),
                                     RecipeInfoHelper.getGasName(recipe.getOutput().getGasOutput()),
                                     recipe.extraEnergy,
                                     recipe.ticks
@@ -271,9 +270,9 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof PurificationRecipe) {
                         PurificationRecipe recipe = (PurificationRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.purification.addRecipe(%s, %s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().itemStack),
+                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
                               RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
                         ));
                     }
                 }
@@ -297,8 +296,8 @@ public class MekRecipesCommand extends CraftTweakerCommand {
                     if (value instanceof ThermalEvaporationRecipe) {
                         ThermalEvaporationRecipe recipe = (ThermalEvaporationRecipe) value;
                         CraftTweakerAPI.logCommand(String.format("mods.mekanism.thermalevaporation.addRecipe(%s, %s)",
-                              LogHelper.getStackDescription(recipe.getInput().ingredient),
-                              LogHelper.getStackDescription(recipe.getOutput().output)
+                              RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
+                              RecipeInfoHelper.getFluidName(recipe.getOutput().output)
                         ));
                     }
                 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/gas/GasBracketHandler.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/gas/GasBracketHandler.java
@@ -2,7 +2,6 @@ package mekanism.common.integration.crafttweaker.gas;
 
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.BracketHandler;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IngredientAny;
 import crafttweaker.zenscript.IBracketHandler;
@@ -20,7 +19,6 @@ import stanhebben.zenscript.type.natives.IJavaMethod;
 import stanhebben.zenscript.util.ZenPosition;
 
 @BracketHandler(priority = 100)
-@ModOnly("mtlib")
 @ZenRegister
 public class GasBracketHandler implements IBracketHandler {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasDefinition.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasDefinition.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.gas;
 
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import stanhebben.zenscript.annotations.OperatorType;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -8,7 +7,6 @@ import stanhebben.zenscript.annotations.ZenGetter;
 import stanhebben.zenscript.annotations.ZenOperator;
 
 @ZenClass("mod.mekanism.gas.IGasDefinition")
-@ModOnly("mtlib")
 @ZenRegister
 public interface IGasDefinition {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.gas;
 
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import stanhebben.zenscript.annotations.OperatorType;
@@ -10,7 +9,6 @@ import stanhebben.zenscript.annotations.ZenMethod;
 import stanhebben.zenscript.annotations.ZenOperator;
 
 @ZenClass("mod.mekanism.gas.IGasStack")
-@ModOnly("mtlib")
 @ZenRegister
 public interface IGasStack extends IIngredient {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalCrystallizer.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.crystallizer")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalCrystallizer {
 
@@ -34,7 +31,7 @@ public class ChemicalCrystallizer {
         if (IngredientHelper.checkNotNull(NAME, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_CRYSTALLIZER,
-                        new CrystallizerRecipe(GasHelper.toGas(gasInput), InputHelper.toStack(itemOutput))));
+                        new CrystallizerRecipe(GasHelper.toGas(gasInput), IngredientHelper.toStack(itemOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalDissolution.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalDissolution.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.dissolution")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalDissolution {
 
@@ -34,7 +31,7 @@ public class ChemicalDissolution {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER,
-                        new DissolutionRecipe(InputHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
+                        new DissolutionRecipe(IngredientHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInfuser.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInfuser.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import mekanism.common.Mekanism;
@@ -21,7 +20,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.infuser")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalInfuser {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInjection.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInjection.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.injection")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalInjection {
 
@@ -34,9 +31,9 @@ public class ChemicalInjection {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER,
-                        new InjectionRecipe(new AdvancedMachineInput(InputHelper.toStack(itemInput),
+                        new InjectionRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
-                              new ItemStackOutput(InputHelper.toStack(itemOutput)))));
+                              new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalOxidizer.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.oxidizer")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalOxidizer {
 
@@ -34,7 +31,7 @@ public class ChemicalOxidizer {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_OXIDIZER,
-                        new OxidationRecipe(InputHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
+                        new OxidationRecipe(IngredientHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalWasher.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalWasher.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import mekanism.common.Mekanism;
@@ -21,7 +20,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.chemical.washer")
-@ModOnly("mtlib")
 @ZenRegister
 public class ChemicalWasher {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -21,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.combiner")
-@ModOnly("mtlib")
 @ZenRegister
 public class Combiner {
 
@@ -31,8 +28,8 @@ public class Combiner {
     public static void addRecipe(IItemStack itemInput, IItemStack extraInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, extraInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.COMBINER, new CombinerRecipe(
-                  new DoubleMachineInput(InputHelper.toStack(itemInput), InputHelper.toStack(extraInput)),
-                  new ItemStackOutput(InputHelper.toStack(itemOutput)))));
+                  new DoubleMachineInput(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(extraInput)),
+                  new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 
@@ -45,7 +42,7 @@ public class Combiner {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.COMBINER,
-                  new CombinerRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                  new CombinerRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Compressor.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Compressor.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.compressor")
-@ModOnly("mtlib")
 @ZenRegister
 public class Compressor {
 
@@ -34,7 +31,8 @@ public class Compressor {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.OSMIUM_COMPRESSOR,
-                        new OsmiumCompressorRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                        new OsmiumCompressorRecipe(IngredientHelper.toStack(itemInput),
+                              IngredientHelper.toStack(itemOutput))));
         }
     }
 
@@ -43,9 +41,9 @@ public class Compressor {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.OSMIUM_COMPRESSOR,
-                        new OsmiumCompressorRecipe(new AdvancedMachineInput(InputHelper.toStack(itemInput),
+                        new OsmiumCompressorRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
-                              new ItemStackOutput(InputHelper.toStack(itemOutput)))));
+                              new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Crusher.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Crusher.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -21,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.crusher")
-@ModOnly("mtlib")
 @ZenRegister
 public class Crusher {
 
@@ -31,7 +28,7 @@ public class Crusher {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.CRUSHER,
-                  new CrusherRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                  new CrusherRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/EnergizedSmelter.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/EnergizedSmelter.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -21,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.smelter")
-@ModOnly("mtlib")
 @ZenRegister
 public class EnergizedSmelter {
 
@@ -42,7 +39,7 @@ public class EnergizedSmelter {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.ENERGIZED_SMELTER,
-                        new SmeltingRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                        new SmeltingRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
             addedRecipe = true;
         }
     }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Enrichment.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Enrichment.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -21,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.enrichment")
-@ModOnly("mtlib")
 @ZenRegister
 public class Enrichment {
 
@@ -32,7 +29,8 @@ public class Enrichment {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.ENRICHMENT_CHAMBER,
-                        new EnrichmentRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                        new EnrichmentRecipe(IngredientHelper.toStack(itemInput),
+                              IngredientHelper.toStack(itemOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Infuser.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Infuser.java
@@ -1,8 +1,6 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import com.blamejared.mtlib.helpers.LogHelper;
-import crafttweaker.annotations.ModOnly;
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.infuser")
-@ModOnly("mtlib")
 @ZenRegister
 public class Infuser {
 
@@ -32,15 +29,15 @@ public class Infuser {
     @ZenMethod
     public static void addRecipe(String infuseType, int infuseAmount, IItemStack itemInput, IItemStack itemOutput) {
         if (infuseType == null || infuseType.isEmpty()) {
-            LogHelper.logError(String.format("Required parameters missing for %s Recipe.", NAME));
+            CraftTweakerAPI.logError(String.format("Required parameters missing for %s Recipe.", NAME));
             return;
         }
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.METALLURGIC_INFUSER,
                         new MetallurgicInfuserRecipe(new InfusionInput(InfuseRegistry.get(infuseType), infuseAmount,
-                              InputHelper.toStack(itemInput)),
-                              new ItemStackOutput(InputHelper.toStack(itemOutput)))));
+                              IngredientHelper.toStack(itemInput)),
+                              new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Purification.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Purification.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.purification")
-@ModOnly("mtlib")
 @ZenRegister
 public class Purification {
 
@@ -34,7 +31,8 @@ public class Purification {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.PURIFICATION_CHAMBER,
-                        new PurificationRecipe(InputHelper.toStack(itemInput), InputHelper.toStack(itemOutput))));
+                        new PurificationRecipe(IngredientHelper.toStack(itemInput),
+                              IngredientHelper.toStack(itemOutput))));
         }
     }
 
@@ -43,9 +41,9 @@ public class Purification {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.PURIFICATION_CHAMBER,
-                        new PurificationRecipe(new AdvancedMachineInput(InputHelper.toStack(itemInput),
+                        new PurificationRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
-                              new ItemStackOutput(InputHelper.toStack(itemOutput)))));
+                              new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Reaction.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Reaction.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -24,7 +22,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.reaction")
-@ModOnly("mtlib")
 @ZenRegister
 public class Reaction {
 
@@ -37,9 +34,9 @@ public class Reaction {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER,
                         new PressurizedRecipe(
-                              new PressurizedInput(InputHelper.toStack(itemInput), InputHelper.toFluid(liquidInput),
-                                    GasHelper.toGas(gasInput)),
-                              new PressurizedOutput(InputHelper.toStack(itemOutput), GasHelper.toGas(gasOutput)),
+                              new PressurizedInput(IngredientHelper.toStack(itemInput),
+                                    IngredientHelper.toFluid(liquidInput), GasHelper.toGas(gasInput)),
+                              new PressurizedOutput(IngredientHelper.toStack(itemOutput), GasHelper.toGas(gasOutput)),
                               energy, duration)));
         }
     }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Sawmill.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Sawmill.java
@@ -1,8 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import static com.blamejared.mtlib.helpers.InputHelper.toStack;
-
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
@@ -22,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.sawmill")
-@ModOnly("mtlib")
 @ZenRegister
 public class Sawmill {
 
@@ -34,10 +30,10 @@ public class Sawmill {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.PRECISION_SAWMILL,
-                        new SawmillRecipe(new ItemStackInput(toStack(itemInput)),
-                              optionalItemOutput == null ? new ChanceOutput(toStack(itemOutput))
-                                    : new ChanceOutput(toStack(itemOutput), toStack(optionalItemOutput),
-                                          optionalChance))));
+                        new SawmillRecipe(new ItemStackInput(IngredientHelper.toStack(itemInput)),
+                              optionalItemOutput == null ? new ChanceOutput(IngredientHelper.toStack(itemOutput))
+                                    : new ChanceOutput(IngredientHelper.toStack(itemOutput),
+                                          IngredientHelper.toStack(optionalItemOutput), optionalChance))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Separator.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Separator.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.liquid.ILiquidStack;
@@ -23,7 +21,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.separator")
-@ModOnly("mtlib")
 @ZenRegister
 public class Separator {
 
@@ -35,8 +32,8 @@ public class Separator {
         if (IngredientHelper.checkNotNull(NAME, liquidInput, leftGasOutput, rightGasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.ELECTROLYTIC_SEPARATOR,
-                        new SeparatorRecipe(InputHelper.toFluid(liquidInput), energy, GasHelper.toGas(leftGasOutput),
-                              GasHelper.toGas(rightGasOutput))));
+                        new SeparatorRecipe(IngredientHelper.toFluid(liquidInput), energy,
+                              GasHelper.toGas(leftGasOutput), GasHelper.toGas(rightGasOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/SolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/SolarNeutronActivator.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import mekanism.common.Mekanism;
@@ -21,7 +20,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.solarneutronactivator")
-@ModOnly("mtlib")
 @ZenRegister
 public class SolarNeutronActivator {
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ThermalEvaporation.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ThermalEvaporation.java
@@ -1,7 +1,5 @@
 package mekanism.common.integration.crafttweaker.handlers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.liquid.ILiquidStack;
@@ -21,7 +19,6 @@ import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 @ZenClass("mods.mekanism.thermalevaporation")
-@ModOnly("mtlib")
 @ZenRegister
 public class ThermalEvaporation {
 
@@ -32,8 +29,8 @@ public class ThermalEvaporation {
         if (IngredientHelper.checkNotNull(NAME, liquidInput, liquidOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
                   .add(new AddMekanismRecipe(NAME, Recipe.THERMAL_EVAPORATION_PLANT,
-                        new ThermalEvaporationRecipe(InputHelper.toFluid(liquidInput),
-                              InputHelper.toFluid(liquidOutput))));
+                        new ThermalEvaporationRecipe(IngredientHelper.toFluid(liquidInput),
+                              IngredientHelper.toFluid(liquidOutput))));
         }
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/helpers/IngredientHelper.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/helpers/IngredientHelper.java
@@ -1,12 +1,12 @@
 package mekanism.common.integration.crafttweaker.helpers;
 
-import com.blamejared.mtlib.helpers.InputHelper;
-import com.blamejared.mtlib.helpers.LogHelper;
-import com.blamejared.mtlib.helpers.StackHelper;
+import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.item.IngredientAny;
 import crafttweaker.api.liquid.ILiquidStack;
+import crafttweaker.mc1120.item.MCItemStack;
+import crafttweaker.mc1120.liquid.MCLiquidStack;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.common.integration.crafttweaker.gas.CraftTweakerGasStack;
@@ -31,6 +31,7 @@ import mekanism.common.recipe.outputs.MachineOutput;
 import mekanism.common.recipe.outputs.PressurizedOutput;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
 public class IngredientHelper {
@@ -45,7 +46,7 @@ public class IngredientHelper {
     public static boolean checkNotNull(String name, IIngredient... ingredients) {
         for (IIngredient ingredient : ingredients) {
             if (ingredient == null) {
-                LogHelper.logError(String.format("Required parameters missing for %s Recipe.", name));
+                CraftTweakerAPI.logError(String.format("Required parameters missing for %s Recipe.", name));
                 return false;
             }
         }
@@ -54,15 +55,15 @@ public class IngredientHelper {
 
     private static IIngredient getIngredient(Object ingredient) {
         if (ingredient instanceof ItemStack) {
-            return InputHelper.toIItemStack((ItemStack) ingredient);
+            return toIItemStack((ItemStack) ingredient);
         } else if (ingredient instanceof GasStack) {
             return new CraftTweakerGasStack((GasStack) ingredient);
         } else if (ingredient instanceof Gas) {
             return new CraftTweakerGasStack(new GasStack((Gas) ingredient, 1));
         } else if (ingredient instanceof FluidStack) {
-            return InputHelper.toILiquidStack((FluidStack) ingredient);
+            return toILiquidStack((FluidStack) ingredient);
         } else if (ingredient instanceof Fluid) {
-            return InputHelper.toILiquidStack(new FluidStack((Fluid) ingredient, 1));
+            return toILiquidStack(new FluidStack((Fluid) ingredient, 1));
         }
         //TODO: Support other types of things like ore dict
         return IngredientAny.INSTANCE;
@@ -72,9 +73,9 @@ public class IngredientHelper {
         if (input instanceof IGasStack) {
             return GasHelper.matches(toMatch, (IGasStack) input);
         } else if (input instanceof IItemStack) {
-            return StackHelper.matches(toMatch, (IItemStack) input);
+            return ingredientMatchesStack(toMatch, (IItemStack) input);
         } else if (input instanceof ILiquidStack) {
-            return StackHelper.matches(toMatch, (ILiquidStack) input);
+            return ingredientMatchesLiquid(toMatch, (ILiquidStack) input);
         }
         //TODO: Support other types of things like ore dict
         return false;
@@ -141,5 +142,56 @@ public class IngredientHelper {
                   toMatch.getRight());
         }
         return false;
+    }
+
+    public static ILiquidStack toILiquidStack(FluidStack stack) {
+        return stack == null ? null : new MCLiquidStack(stack);
+    }
+
+    public static IItemStack toIItemStack(ItemStack stack) {
+        return stack.isEmpty() ? null : new MCItemStack(stack);
+    }
+
+    public static ItemStack toStack(IItemStack stack) {
+        if (stack != null) {
+            Object internal = stack.getInternal();
+            if (internal instanceof ItemStack) {
+                return (ItemStack) internal;
+            } else {
+                CraftTweakerAPI.logError("Not a valid item stack: " + stack);
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+
+    public static FluidStack toFluid(ILiquidStack fluid) {
+        return fluid == null ? null : FluidRegistry.getFluidStack(fluid.getName(), fluid.getAmount());
+    }
+
+    public static boolean ingredientMatchesStack(IIngredient ingredient, IItemStack itemStack) {
+        return ingredient != null && ingredient.matches(itemStack);
+    }
+
+    public static boolean ingredientMatchesLiquid(IIngredient ingredient, ILiquidStack liquidStack) {
+        return ingredient != null && ingredient.matches(liquidStack);
+        /*if(ingredient == null) {
+            return false;
+        }
+
+        // Do we have a wildcard (<*>) ?
+        if(ingredient.matches(liquidStack)) {
+            return true;
+        }
+
+        // Does ingredient reference liquids?
+        if(ingredient.getLiquids() != null) {
+            for (ILiquidStack liquid : ingredient.getLiquids()) {
+                if(InputHelper.toFluid(liquid).isFluidEqual(InputHelper.toFluid(liquidStack))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;*/
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/helpers/IngredientHelper.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/helpers/IngredientHelper.java
@@ -73,9 +73,9 @@ public class IngredientHelper {
         if (input instanceof IGasStack) {
             return GasHelper.matches(toMatch, (IGasStack) input);
         } else if (input instanceof IItemStack) {
-            return ingredientMatchesStack(toMatch, (IItemStack) input);
+            return toMatch != null && toMatch.matches((IItemStack) input);
         } else if (input instanceof ILiquidStack) {
-            return ingredientMatchesLiquid(toMatch, (ILiquidStack) input);
+            return toMatch != null && toMatch.matches((ILiquidStack) input);
         }
         //TODO: Support other types of things like ore dict
         return false;
@@ -166,32 +166,5 @@ public class IngredientHelper {
 
     public static FluidStack toFluid(ILiquidStack fluid) {
         return fluid == null ? null : FluidRegistry.getFluidStack(fluid.getName(), fluid.getAmount());
-    }
-
-    public static boolean ingredientMatchesStack(IIngredient ingredient, IItemStack itemStack) {
-        return ingredient != null && ingredient.matches(itemStack);
-    }
-
-    public static boolean ingredientMatchesLiquid(IIngredient ingredient, ILiquidStack liquidStack) {
-        return ingredient != null && ingredient.matches(liquidStack);
-        /*if(ingredient == null) {
-            return false;
-        }
-
-        // Do we have a wildcard (<*>) ?
-        if(ingredient.matches(liquidStack)) {
-            return true;
-        }
-
-        // Does ingredient reference liquids?
-        if(ingredient.getLiquids() != null) {
-            for (ILiquidStack liquid : ingredient.getLiquids()) {
-                if(InputHelper.toFluid(liquid).isFluidEqual(InputHelper.toFluid(liquidStack))) {
-                    return true;
-                }
-            }
-        }
-
-        return false;*/
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/helpers/RecipeInfoHelper.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/helpers/RecipeInfoHelper.java
@@ -1,6 +1,6 @@
 package mekanism.common.integration.crafttweaker.helpers;
 
-import com.blamejared.mtlib.helpers.LogHelper;
+import crafttweaker.mc1120.item.MCItemStack;
 import java.util.Map;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -13,6 +13,9 @@ import mekanism.common.recipe.outputs.GasOutput;
 import mekanism.common.recipe.outputs.ItemStackOutput;
 import mekanism.common.recipe.outputs.MachineOutput;
 import mekanism.common.recipe.outputs.PressurizedOutput;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
 
 public class RecipeInfoHelper {
 
@@ -22,20 +25,19 @@ public class RecipeInfoHelper {
     public static String getRecipeInfo(Map.Entry<? extends MachineInput, ? extends MachineRecipe> recipe) {
         MachineOutput output = recipe.getValue().recipeOutput;
         if (output instanceof ItemStackOutput) {
-            return LogHelper.getStackDescription(((ItemStackOutput) output).output);
+            return getItemName(((ItemStackOutput) output).output);
         } else if (output instanceof GasOutput) {
             return getGasName(((GasOutput) output).output);
         } else if (output instanceof FluidOutput) {
-            return LogHelper.getStackDescription(((FluidOutput) output).output);
+            return getFluidName(((FluidOutput) output).output);
         } else if (output instanceof ChemicalPairOutput) {
             ChemicalPairOutput out = (ChemicalPairOutput) output;
             return "[" + getGasName(out.leftGas) + ", " + getGasName(out.rightGas) + "]";
         } else if (output instanceof ChanceOutput) {
-            return LogHelper.getStackDescription(((ChanceOutput) output).primaryOutput);
+            return getItemName(((ChanceOutput) output).primaryOutput);
         } else if (output instanceof PressurizedOutput) {
             PressurizedOutput out = (PressurizedOutput) output;
-            return "[" + LogHelper.getStackDescription(out.getItemOutput()) + ", " + getGasName(out.getGasOutput())
-                  + "]";
+            return "[" + getItemName(out.getItemOutput()) + ", " + getGasName(out.getGasOutput()) + "]";
         }
         return null;
     }
@@ -47,5 +49,18 @@ public class RecipeInfoHelper {
 
     public static String getGasName(Gas gas) {
         return String.format("<gas:%s>", gas.getName());
+    }
+
+    public static String getFluidName(FluidStack stack) {
+        return stack.amount > 1 ? String.format("<liquid:%s> * %s", stack.getFluid().getName(), stack.amount)
+              : getFluidName(stack.getFluid());
+    }
+
+    public static String getFluidName(Fluid fluid) {
+        return String.format("<liquid:%s>", fluid.getName());
+    }
+
+    public static String getItemName(ItemStack stack) {
+        return new MCItemStack(stack).toString();
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/AddMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/AddMekanismRecipe.java
@@ -1,21 +1,13 @@
 package mekanism.common.integration.crafttweaker.util;
 
-import com.blamejared.mtlib.utils.BaseMapAddition;
-import java.util.Map;
-import mekanism.common.integration.crafttweaker.helpers.RecipeInfoHelper;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
 
-public class AddMekanismRecipe extends BaseMapAddition<MachineInput, MachineRecipe> {
+public class AddMekanismRecipe extends RecipeMapModification<MachineInput, MachineRecipe> {
 
     public AddMekanismRecipe(String name, Recipe recipeType, MachineRecipe recipe) {
-        super(name, recipeType.get());
+        super(name, true, recipeType);
         recipes.put(recipe.getInput(), recipe);
-    }
-
-    @Override
-    protected String getRecipeInfo(Map.Entry<MachineInput, MachineRecipe> recipe) {
-        return RecipeInfoHelper.getRecipeInfo(recipe);
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/IngredientWrapper.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/IngredientWrapper.java
@@ -1,9 +1,7 @@
 package mekanism.common.integration.crafttweaker.util;
 
-import com.blamejared.mtlib.helpers.LogHelper;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IngredientAny;
-import mekanism.common.integration.crafttweaker.gas.IGasStack;
 import mekanism.common.integration.crafttweaker.helpers.IngredientHelper;
 
 public class IngredientWrapper {
@@ -84,6 +82,6 @@ public class IngredientWrapper {
     }
 
     private String getDescriptor(IIngredient ingredient) {
-        return ingredient instanceof IGasStack ? ingredient.toCommandString() : LogHelper.getStackDescription(ingredient);
+        return ingredient.toCommandString();
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
@@ -1,0 +1,65 @@
+package mekanism.common.integration.crafttweaker.util;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import mekanism.common.integration.crafttweaker.helpers.RecipeInfoHelper;
+import mekanism.common.recipe.RecipeHandler.Recipe;
+import mekanism.common.recipe.inputs.MachineInput;
+import mekanism.common.recipe.machines.MachineRecipe;
+
+public abstract class RecipeMapModification<K extends MachineInput, V extends MachineRecipe> implements IAction {
+
+    protected final HashMap<K, V> recipes;
+    protected final Map<K, V> map;
+    protected final String name;
+    protected boolean add;
+
+    protected RecipeMapModification(String name, boolean add, Recipe recipeType) {
+        this.name = name;
+        this.map = recipeType.get();
+        this.add = add;
+        this.recipes = new HashMap<>();
+    }
+
+    @Override
+    public void apply() {
+        if (!recipes.isEmpty()) {
+            if (add) {
+                for (Entry<K, V> entry : recipes.entrySet()) {
+                    K key = entry.getKey();
+                    V value = entry.getValue();
+                    if (map.put(key, value) != null) {
+                        CraftTweakerAPI.logInfo(String.format("Overwritten %s Recipe for %s", name,
+                              RecipeInfoHelper.getRecipeInfo(new AbstractMap.SimpleEntry<>(entry.getKey(), value))));
+                    }
+                }
+            } else {
+                for (K key : recipes.keySet()) {
+                    if (map.remove(key) == null) {
+                        CraftTweakerAPI.logError(String.format("Error removing %s Recipe : null object", name));
+                    }
+                }
+            }
+        }
+    }
+
+    private String getRecipeInfo() {
+        if (!recipes.isEmpty()) {
+            return recipes.entrySet().stream().filter(Objects::nonNull).map(RecipeInfoHelper::getRecipeInfo)
+                  .collect(Collectors.joining(", "));
+        }
+        return "Unknown item";
+    }
+
+    @Override
+    public String describe() {
+        return String.format("Removing %d %s Recipe(s) for %s", recipes.size(), name, getRecipeInfo());
+    }
+
+}

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveAllMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveAllMekanismRecipe.java
@@ -1,17 +1,13 @@
 package mekanism.common.integration.crafttweaker.util;
 
-import com.blamejared.mtlib.helpers.LogHelper;
-import com.blamejared.mtlib.utils.BaseMapRemoval;
-import java.util.Map.Entry;
-import mekanism.common.integration.crafttweaker.helpers.RecipeInfoHelper;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
 
-public class RemoveAllMekanismRecipe<RECIPE extends MachineRecipe> extends BaseMapRemoval<MachineInput, RECIPE> {
+public class RemoveAllMekanismRecipe<RECIPE extends MachineRecipe> extends RecipeMapModification<MachineInput, RECIPE> {
 
     public RemoveAllMekanismRecipe(String name, Recipe recipeType) {
-        super(name, recipeType.get());
+        super(name, false, recipeType);
     }
 
     @Override
@@ -19,17 +15,10 @@ public class RemoveAllMekanismRecipe<RECIPE extends MachineRecipe> extends BaseM
         //Don't move this into the constructor so that if an addon registers recipes late, we can still remove them
         recipes.putAll(map);
         super.apply();
-        LogHelper.logInfo("Removed all recipes for " + name);
     }
 
     @Override
     public String describe() {
-        //Don't describe anything. It is too early for us to have a full description
-        return null;
-    }
-
-    @Override
-    protected String getRecipeInfo(Entry<MachineInput, RECIPE> recipe) {
-        return RecipeInfoHelper.getRecipeInfo(recipe);
+        return "Removed all recipes for " + name;
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveMekanismRecipe.java
@@ -1,23 +1,20 @@
 package mekanism.common.integration.crafttweaker.util;
 
-import com.blamejared.mtlib.helpers.LogHelper;
-import com.blamejared.mtlib.utils.BaseMapRemoval;
-import java.util.Map;
+import crafttweaker.CraftTweakerAPI;
 import mekanism.common.integration.crafttweaker.helpers.IngredientHelper;
-import mekanism.common.integration.crafttweaker.helpers.RecipeInfoHelper;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
 import mekanism.common.recipe.outputs.MachineOutput;
 
 public class RemoveMekanismRecipe<INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>> extends
-      BaseMapRemoval<INPUT, RECIPE> {
+      RecipeMapModification<INPUT, RECIPE> {
 
     private final IngredientWrapper input;
     private final IngredientWrapper output;
 
     public RemoveMekanismRecipe(String name, Recipe recipeType, IngredientWrapper output, IngredientWrapper input) {
-        super(name, recipeType.get());
+        super(name, false, recipeType);
         this.input = input;
         this.output = output;
     }
@@ -43,18 +40,13 @@ public class RemoveMekanismRecipe<INPUT extends MachineInput<INPUT>, OUTPUT exte
                 warning = String.format("input: '%s' and output: '%s'", input.toString(), output.toString());
             }
             if (!warning.isEmpty()) {
-                LogHelper.logWarning(String.format("No %s recipe found for %s. Command ignored!", name, warning));
+                CraftTweakerAPI.logWarning(String.format("No %s recipe found for %s. Command ignored!", name, warning));
             }
         } else {
             super.apply();
             //Describe it, as we don't describe it when describe is normally used as we don't have the information yet
-            LogHelper.logInfo(super.describe());
+            CraftTweakerAPI.logInfo(super.describe());
         }
-    }
-
-    @Override
-    protected String getRecipeInfo(Map.Entry<INPUT, RECIPE> recipe) {
-        return RecipeInfoHelper.getRecipeInfo(recipe);
     }
 
     @Override


### PR DESCRIPTION
Makes it easier for people to know what is needed for the CraftTweaker support, as they don't have to realize they need to go and install MTLib.