### PR TITLE
Address #47; overhaul how turbine rotors work

### DIFF
--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -27,7 +27,6 @@ import mekanism.api.transmitters.DynamicNetwork.TransmittersAddedEvent;
 import mekanism.api.transmitters.TransmitterNetworkRegistry;
 import mekanism.client.ClientTickHandler;
 import mekanism.common.Tier.BaseTier;
-import mekanism.common.base.IChunkLoadHandler;
 import mekanism.common.base.IModule;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
@@ -1140,19 +1139,6 @@ public class Mekanism {
         }
 
         BoxBlacklistParser.load();
-    }
-
-    @SubscribeEvent
-    public synchronized void onChunkLoad(ChunkEvent.Load event) {
-        if (event.getChunk() != null && !event.getWorld().isRemote) {
-            Map<BlockPos, TileEntity> copy = new HashMap<>(event.getChunk().getTileEntityMap());
-
-            for (TileEntity tileEntity : copy.values()) {
-                if (tileEntity instanceof IChunkLoadHandler) {
-                    ((IChunkLoadHandler) tileEntity).onChunkLoad();
-                }
-            }
-        }
     }
 
     @SubscribeEvent

--- a/src/main/java/mekanism/common/base/IChunkLoadHandler.java
+++ b/src/main/java/mekanism/common/base/IChunkLoadHandler.java
@@ -1,6 +1,0 @@
-package mekanism.common.base;
-
-public interface IChunkLoadHandler {
-
-    void onChunkLoad();
-}

--- a/src/main/java/mekanism/common/multiblock/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/multiblock/TileEntityInternalMultiblock.java
@@ -44,4 +44,6 @@ public class TileEntityInternalMultiblock extends TileEntityBasicBlock {
     public void setMultiblock(String id) {
         multiblockUUID = id;
     }
+
+    public String getMultiblock() { return multiblockUUID; }
 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -8,7 +8,6 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
 import mekanism.common.Mekanism;
-import mekanism.common.base.IChunkLoadHandler;
 import mekanism.common.base.ITileComponent;
 import mekanism.common.base.ITileNetwork;
 import mekanism.common.base.TileNetworkList;
@@ -36,8 +35,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Optional.Interface;
 
 @Interface(iface = "ic2.api.tile.IWrenchable", modid = MekanismHooks.IC2_MOD_ID)
-public abstract class TileEntityBasicBlock extends TileEntity implements ITileNetwork, IChunkLoadHandler,
-      IFrequencyHandler, ITickable {
+public abstract class TileEntityBasicBlock extends TileEntity implements ITileNetwork, IFrequencyHandler, ITickable {
 
     /**
      * The direction this block is facing.
@@ -102,11 +100,6 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         super.updateContainingBlockInfo();
 
         onAdded();
-    }
-
-    @Override
-    public void onChunkLoad() {
-
     }
 
     public void open(EntityPlayer player) {

--- a/src/main/java/mekanism/generators/client/render/RenderTurbineRotor.java
+++ b/src/main/java/mekanism/generators/client/render/RenderTurbineRotor.java
@@ -26,7 +26,7 @@ public class RenderTurbineRotor extends TileEntitySpecialRenderer<TileEntityTurb
     }
 
     private void renderAModelAt(TileEntityTurbineRotor tileEntity, double x, double y, double z, float partialTick) {
-        if (tileEntity.multiblockUUID != null && !internalRender) {
+        if (tileEntity.getMultiblock() != null && !internalRender) {
             return;
         }
 
@@ -34,12 +34,12 @@ public class RenderTurbineRotor extends TileEntitySpecialRenderer<TileEntityTurb
 
         bindTexture(MekanismUtils.getResource(ResourceType.RENDER, "Turbine.png"));
 
-        int baseIndex = tileEntity.clientIndex * 2;
+        int baseIndex = tileEntity.getPosition() * 2;
         float rotateSpeed = 0.0F;
 
-        if (tileEntity.multiblockUUID != null && SynchronizedTurbineData.clientRotationMap
-              .containsKey(tileEntity.multiblockUUID)) {
-            rotateSpeed = SynchronizedTurbineData.clientRotationMap.get(tileEntity.multiblockUUID);
+        if (tileEntity.getMultiblock() != null && SynchronizedTurbineData.clientRotationMap
+              .containsKey(tileEntity.getMultiblock())) {
+            rotateSpeed = SynchronizedTurbineData.clientRotationMap.get(tileEntity.getMultiblock());
         }
 
         if (!Mekanism.proxy.isPaused()) {

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -389,7 +389,7 @@ public abstract class BlockGenerator extends BlockContainer {
 
             if (!entityplayer.isSneaking()) {
                 if (!stack.isEmpty() && stack.getItem() == GeneratorsItems.TurbineBlade) {
-                    if (rod.editBlade(true)) {
+                    if (rod.addBlade()) {
                         if (!entityplayer.capabilities.isCreativeMode) {
                             stack.shrink(1);
 
@@ -402,7 +402,7 @@ public abstract class BlockGenerator extends BlockContainer {
                     return true;
                 }
             } else if (stack.isEmpty()) {
-                if (rod.editBlade(false)) {
+                if (rod.removeBlade()) {
                     if (!entityplayer.capabilities.isCreativeMode) {
                         entityplayer.setHeldItem(hand, new ItemStack(GeneratorsItems.TurbineBlade));
                         entityplayer.inventory.markDirty();
@@ -410,7 +410,7 @@ public abstract class BlockGenerator extends BlockContainer {
                 }
             } else if (stack.getItem() == GeneratorsItems.TurbineBlade) {
                 if (stack.getCount() < stack.getMaxStackSize()) {
-                    if (rod.editBlade(false)) {
+                    if (rod.removeBlade()) {
                         if (!entityplayer.capabilities.isCreativeMode) {
                             stack.grow(1);
                             entityplayer.inventory.markDirty();

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
@@ -9,30 +9,28 @@ import mekanism.api.Range4D;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
 import mekanism.common.base.TileNetworkList;
+import mekanism.common.multiblock.TileEntityInternalMultiblock;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityBasicBlock;
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class TileEntityTurbineRotor extends TileEntityBasicBlock {
+public class TileEntityTurbineRotor extends TileEntityInternalMultiblock {
 
-    public List<Coord4D> rotors = new ArrayList<>();
-
-    public boolean hasComplex;
-
-    public String multiblockUUID;
-
-    //Total blades on server, housed blades on client
+    // Blades on this rotor
     public int blades = 0;
 
-    //Client stuff
-    public int clientIndex;
+    // Position of this rotor, relative to bottom
+    private int position = -1;
 
+    // Rendering helpers
     public float rotationLower;
     public float rotationUpper;
 
@@ -44,130 +42,106 @@ public class TileEntityTurbineRotor extends TileEntityBasicBlock {
     }
 
     public void updateRotors() {
-        if (rotors.contains(Coord4D.get(this))) {
-            rotors.add(Coord4D.get(this));
-        }
+        // In order to render properly, each rotor has to know its position, relative to other contiguous rotors
+        // along the Z axis. When a neighbor changes, rescan the rotors and figure out everyone's position
+        // N.B. must be in bottom->top order.
 
-        buildRotors();
-        Mekanism.packetHandler
-              .sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                    new Range4D(Coord4D.get(this)));
-    }
-
-    private void buildRotors() {
-        List<Coord4D> newRotors = new ArrayList<>();
-        int newBlades = 0;
-        boolean complex = false;
-        String id = null;
-
-        Coord4D pointer = Coord4D.get(this);
-
-        //Go to bottom rotor
-        while (true) {
-            if (isRotor(pointer.offset(EnumFacing.DOWN))) {
-                pointer = pointer.offset(EnumFacing.DOWN);
-                continue;
-            }
-
-            break;
-        }
-
-        //Put all rotors in new list, top to bottom
-        while (true) {
-            newRotors.add(pointer.clone());
-            newBlades += ((TileEntityTurbineRotor) pointer.getTileEntity(world)).getHousedBlades();
-
-            if (isRotor(pointer.offset(EnumFacing.UP))) {
-                pointer = pointer.offset(EnumFacing.UP);
-                continue;
-            }
-
-            break;
-        }
-
-        if (isComplex(pointer.offset(EnumFacing.UP))) {
-            id = ((TileEntityRotationalComplex) pointer.offset(EnumFacing.UP).getTileEntity(world)).multiblockUUID;
-            complex = true;
-        }
-
-        //Update all rotors, send packet if necessary
-        for (Coord4D coord : newRotors) {
-            TileEntityTurbineRotor rotor = (TileEntityTurbineRotor) coord.getTileEntity(world);
-            int prevHoused = rotor.getHousedBlades();
-            int prevBlades = rotor.blades;
-
-            rotor.rotors = newRotors;
-            rotor.blades = newBlades;
-            rotor.multiblockUUID = id;
-
-            if (rotors.indexOf(coord) == rotors.size() - 1) {
-                rotor.hasComplex = complex;
-            } else {
-                rotor.hasComplex = false;
-            }
-
-            Mekanism.packetHandler
-                  .sendToReceivers(new TileEntityMessage(coord, rotor.getNetworkedData(new TileNetworkList())),
-                        new Range4D(coord));
+        // Find the bottom-most rotor and start scan from there
+        TileEntityTurbineRotor rotor = nextRotor(getPos().down());
+        if (rotor != null) {
+            rotor.updateRotors();
+        } else {
+            // This is the bottom-most rotor, so start scan up
+            scanRotors(0);
         }
     }
 
-    public boolean editBlade(boolean add) {
-        if (!rotors.contains(Coord4D.get(this))) {
-            rotors.add(Coord4D.get(this));
+    private void scanRotors(int index) {
+        if (index != position) {
+            // Our position has changed, update and generate an update packet for client
+            position = index;
+            sendUpdatePacket();
         }
 
-        if ((add && (rotors.size() * 2) - blades > 0) || (!add && (blades > 0))) {
-            for (Coord4D coord : rotors) {
-                TileEntityTurbineRotor rotor = (TileEntityTurbineRotor) coord.getTileEntity(world);
-                rotor.internalEditBlade(add);
-            }
+        // Pass the scan along to next rotor up, along with their new index
+        TileEntityTurbineRotor rotor = nextRotor(getPos().up());
+        if (rotor != null) {
+            rotor.scanRotors(index+1);
+        }
+    }
+
+
+    public boolean addBlade() {
+        // If the the rotor beneath has less than two blades, add to it
+        TileEntityTurbineRotor next = nextRotor(getPos().down());
+        if (next != null && next.blades < 2) {
+            return next.addBlade();
+        } else if (blades < 2) {
+            // Add the blades to this rotor
+            blades++;
+
+            // Update client state
+            sendUpdatePacket();
 
             return true;
+        }
+
+        // This rotor and the rotor below are full up; pass the call
+        // on up to the next rotor in stack
+        next = nextRotor(getPos().up());
+        if (next != null) {
+            return next.addBlade();
         } else {
             return false;
         }
     }
 
-    public void internalEditBlade(boolean add) {
-        int prev = getHousedBlades();
+    public boolean removeBlade() {
+        // If the the rotor above has any blades, remove them first
+        TileEntityTurbineRotor next = nextRotor(getPos().up());
+        if (next != null && next.blades > 0) {
+            return next.removeBlade();
+        } else if (blades > 0) {
+            // Remove blades from this rotor
+            blades--;
 
-        blades += add ? 1 : -1;
+            // Update client state
+            sendUpdatePacket();
 
-        if (getHousedBlades() != prev) {
-            Mekanism.packetHandler
-                  .sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                        new Range4D(Coord4D.get(this)));
+            return true;
+        }
+
+        // This rotor and the rotor above are empty; pass the call
+        // on up to the next rotor in stack
+        next = nextRotor(getPos().down());
+        if (next != null) {
+            return next.removeBlade();
+        } else {
+            return false;
         }
     }
+
 
     public int getHousedBlades() {
-        if (!world.isRemote) {
-            if (rotors.size() > 0) {
-                return Math.max(0, Math.min(2, blades - (rotors.indexOf(Coord4D.get(this))) * 2));
-            } else {
-                return blades;
-            }
-        } else {
-            return blades;
+        return blades;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    private TileEntityTurbineRotor nextRotor(BlockPos pos) {
+        TileEntity tile = world.getTileEntity(pos);
+        if (tile instanceof TileEntityTurbineRotor) {
+            return (TileEntityTurbineRotor)tile;
         }
+        return null;
     }
 
-    private boolean isRotor(Coord4D coord) {
-        return coord.getTileEntity(world) instanceof TileEntityTurbineRotor;
-    }
-
-    private boolean isComplex(Coord4D coord) {
-        return coord.getTileEntity(world) instanceof TileEntityRotationalComplex;
-    }
-
-    @Override
-    public void onChunkLoad() {
-        super.onChunkLoad();
-
-        if (!world.isRemote) {
-            updateRotors();
-        }
+    private void sendUpdatePacket() {
+        Mekanism.packetHandler
+              .sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
+                    new Range4D(Coord4D.get(this)));
     }
 
     @Override
@@ -176,18 +150,12 @@ public class TileEntityTurbineRotor extends TileEntityBasicBlock {
 
         if (FMLCommonHandler.instance().getEffectiveSide().isClient()) {
             int prevBlades = blades;
-            int prevIndex = clientIndex;
+            int prevPosition = position;
 
             blades = dataStream.readInt();
-            clientIndex = dataStream.readInt();
+            position = dataStream.readInt();
 
-            if (dataStream.readBoolean()) {
-                multiblockUUID = PacketHandler.readString(dataStream);
-            } else {
-                multiblockUUID = null;
-            }
-
-            if (prevBlades != blades || prevIndex != clientIndex) {
+            if (prevBlades != blades || prevPosition != prevBlades) {
                 rotationLower = 0;
                 rotationUpper = 0;
             }
@@ -198,15 +166,8 @@ public class TileEntityTurbineRotor extends TileEntityBasicBlock {
     public TileNetworkList getNetworkedData(TileNetworkList data) {
         super.getNetworkedData(data);
 
-        data.add(getHousedBlades());
-        data.add(rotors.indexOf(Coord4D.get(this)));
-
-        if (multiblockUUID != null) {
-            data.add(true);
-            data.add(multiblockUUID);
-        } else {
-            data.add(false);
-        }
+        data.add(blades);
+        data.add(position);
 
         return data;
     }
@@ -236,6 +197,13 @@ public class TileEntityTurbineRotor extends TileEntityBasicBlock {
     }
 
     @Override
-    public void onUpdate() {
+    public void onUpdate() {}
+
+    @Override
+    public void setMultiblock(String id) {
+        // Override the multiblock setter so that we can be sure to relay the ID down to the client; otherwise,
+        // the rendering won't work properly
+        super.setMultiblock(id);
+        sendUpdatePacket();
     }
 }


### PR DESCRIPTION
Turbine rotors have been the source of numerous issues: #15, #45, etc. Much of this stems from the fact that they have dependencies on the other rotors along the same contiguous Z-axis. 

The prior implementation would use a chunk load event to kick off a re-scan of the number of blades for a given rotor axis -- and then do that for every rotor, even it it had already been scanned, thus generating a n^2 number of sync packets. 

The only time a scan really needs to happen is on neighbor change event; the remaining information can be gathered on demand when placed in a multi-block turbine structure. 