### PR TITLE
Fix #53; add support for comparators on bins

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -816,25 +816,25 @@ public abstract class BlockBasic extends Block {
 
     @Override
     public boolean isBeaconBase(IBlockAccess world, BlockPos pos, BlockPos beacon) {
-        return BasicBlockType.get(world.getBlockState(pos)).isBeaconBase;
+        BasicBlockType basicBlockType = BasicBlockType.get(world.getBlockState(pos));
+        return basicBlockType != null && basicBlockType.isBeaconBase;
     }
 
     @Override
     public boolean hasComparatorInputOverride(IBlockState blockState) {
-        return BasicBlockType.get(blockState).hasRedstoneOutput;
+        BasicBlockType basicBlockType = BasicBlockType.get(blockState);
+        return basicBlockType != null && basicBlockType.hasRedstoneOutput;
     }
 
     @Override
     public int getComparatorInputOverride(IBlockState blockState, World worldIn, BlockPos pos) {
-        if (BasicBlockType.get(blockState).hasRedstoneOutput) {
+        BasicBlockType basicBlockType = BasicBlockType.get(blockState);
+        if (basicBlockType != null && basicBlockType.hasRedstoneOutput) {
             TileEntity tile = worldIn.getTileEntity(pos);
             if (tile instanceof TileEntityBin) {
-                TileEntityBin binTile = (TileEntityBin)tile;
-                float percentFull = binTile.getItemCount() / (binTile.getMaxStoredCount() * 1.0f);
-                return (int)(percentFull * 15);
+                return ((TileEntityBin) tile).getRedstoneLevel();
             }
         }
-
         return 0;
     }
 }

--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -818,4 +818,23 @@ public abstract class BlockBasic extends Block {
     public boolean isBeaconBase(IBlockAccess world, BlockPos pos, BlockPos beacon) {
         return BasicBlockType.get(world.getBlockState(pos)).isBeaconBase;
     }
+
+    @Override
+    public boolean hasComparatorInputOverride(IBlockState blockState) {
+        return BasicBlockType.get(blockState).hasRedstoneOutput;
+    }
+
+    @Override
+    public int getComparatorInputOverride(IBlockState blockState, World worldIn, BlockPos pos) {
+        if (BasicBlockType.get(blockState).hasRedstoneOutput) {
+            TileEntity tile = worldIn.getTileEntity(pos);
+            if (tile instanceof TileEntityBin) {
+                TileEntityBin binTile = (TileEntityBin)tile;
+                float percentFull = binTile.getItemCount() / (binTile.getMaxStoredCount() * 1.0f);
+                return (int)(percentFull * 15);
+            }
+        }
+
+        return 0;
+    }
 }

--- a/src/main/java/mekanism/common/block/states/BlockStateBasic.java
+++ b/src/main/java/mekanism/common/block/states/BlockStateBasic.java
@@ -52,6 +52,7 @@ public class BlockStateBasic extends ExtendedBlockState {
               new IUnlistedProperty[]{});
     }
 
+
     public enum BasicBlock {
         BASIC_BLOCK_1,
         BASIC_BLOCK_2;
@@ -91,7 +92,7 @@ public class BlockStateBasic extends ExtendedBlockState {
               false, true),
         STEEL_BLOCK(BasicBlock.BASIC_BLOCK_1, 5, "SteelBlock", null, false, Predicates.alwaysFalse(), false, false,
               true),
-        BIN(BasicBlock.BASIC_BLOCK_1, 6, "Bin", TileEntityBin.class, true, Plane.HORIZONTAL, true, true, false),
+        BIN(BasicBlock.BASIC_BLOCK_1, 6, "Bin", TileEntityBin.class, true, Plane.HORIZONTAL, true, true, false, true),
         TELEPORTER_FRAME(BasicBlock.BASIC_BLOCK_1, 7, "TeleporterFrame", null, true, Predicates.alwaysFalse(), false,
               false, false),
         STEEL_CASING(BasicBlock.BASIC_BLOCK_1, 8, "SteelCasing", null, true, Predicates.alwaysFalse(), false, false,
@@ -140,6 +141,7 @@ public class BlockStateBasic extends ExtendedBlockState {
         public boolean activable;
         public boolean tiers;
         public boolean isBeaconBase;
+        public boolean hasRedstoneOutput = false;
 
         BasicBlockType(BasicBlock block, int metadata, String s, Class<? extends TileEntity> tileClass, boolean hasDesc,
               Predicate<EnumFacing> facingAllowed, boolean activeState, boolean t, boolean beaconBase) {
@@ -152,6 +154,20 @@ public class BlockStateBasic extends ExtendedBlockState {
             activable = activeState;
             tiers = t;
             isBeaconBase = beaconBase;
+        }
+
+        BasicBlockType(BasicBlock block, int metadata, String s, Class<? extends TileEntity> tileClass, boolean hasDesc,
+              Predicate<EnumFacing> facingAllowed, boolean activeState, boolean t, boolean beaconBase, boolean hasRedstoneOutput) {
+            blockType = block;
+            meta = metadata;
+            name = s;
+            tileEntityClass = tileClass;
+            hasDescription = hasDesc;
+            facingPredicate = facingAllowed;
+            activable = activeState;
+            tiers = t;
+            isBeaconBase = beaconBase;
+            this.hasRedstoneOutput = hasRedstoneOutput;
         }
 
         @Nullable

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -34,6 +34,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.capabilities.Capability;
@@ -547,6 +548,11 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
     @Override
     public boolean lightUpdate() {
         return true;
+    }
+
+    public int getRedstoneLevel() {
+        double fractionFull = (float) getItemCount() / (float) getMaxStoredCount();
+        return MathHelper.floor((float) (fractionFull * 14.0F)) + (fractionFull > 0 ? 1 : 0);
     }
 
     //	@Override


### PR DESCRIPTION
This works as expected, but I have to say that I'm not sure it's implemented properly with block states. It's kind of a mess in how Mek deals with BlockStates (I _think_), so I tried to get it in with minimal changes.