### PR TITLE
Promote RecipeHandler.Recipe to a generic class

### DIFF
--- a/src/main/java/mekanism/client/jei/BaseRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/BaseRecipeCategory.java
@@ -72,7 +72,7 @@ public abstract class BaseRecipeCategory implements IRecipeCategory<IRecipeWrapp
 
     @Override
     public String getUid() {
-        return "mekanism." + recipeName;
+        return recipeName;
     }
 
     @Override

--- a/src/main/java/mekanism/client/jei/MekanismJEI.java
+++ b/src/main/java/mekanism/client/jei/MekanismJEI.java
@@ -122,31 +122,31 @@ public class MekanismJEI implements IModPlugin {
         addRecipeCategory(registry, MachineType.SOLAR_NEUTRON_ACTIVATOR, new SolarNeutronRecipeCategory(guiHelper));
 
         addRecipeCategory(registry, MachineType.COMBINER,
-              new DoubleMachineRecipeCategory(guiHelper, Recipe.COMBINER.getName(),
+              new DoubleMachineRecipeCategory(guiHelper, Recipe.COMBINER.getJEICategory(),
                     "tile.MachineBlock.Combiner.name", ProgressBar.STONE));
 
         addRecipeCategory(registry, MachineType.PURIFICATION_CHAMBER,
-              new AdvancedMachineRecipeCategory(guiHelper, Recipe.PURIFICATION_CHAMBER.getName(),
+              new AdvancedMachineRecipeCategory(guiHelper, Recipe.PURIFICATION_CHAMBER.getJEICategory(),
                     "tile.MachineBlock.PurificationChamber.name", ProgressBar.RED));
         addRecipeCategory(registry, MachineType.OSMIUM_COMPRESSOR,
-              new AdvancedMachineRecipeCategory(guiHelper, Recipe.OSMIUM_COMPRESSOR.getName(),
+              new AdvancedMachineRecipeCategory(guiHelper, Recipe.OSMIUM_COMPRESSOR.getJEICategory(),
                     "tile.MachineBlock.OsmiumCompressor.name", ProgressBar.RED));
         addRecipeCategory(registry, MachineType.CHEMICAL_INJECTION_CHAMBER,
-              new AdvancedMachineRecipeCategory(guiHelper, Recipe.CHEMICAL_INJECTION_CHAMBER.getName(),
+              new AdvancedMachineRecipeCategory(guiHelper, Recipe.CHEMICAL_INJECTION_CHAMBER.getJEICategory(),
                     "tile.MachineBlock2.ChemicalInjectionChamber.name", ProgressBar.YELLOW));
 
         addRecipeCategory(registry, MachineType.PRECISION_SAWMILL,
-              new ChanceMachineRecipeCategory(guiHelper, Recipe.PRECISION_SAWMILL.getName(),
+              new ChanceMachineRecipeCategory(guiHelper, Recipe.PRECISION_SAWMILL.getJEICategory(),
                     "tile.MachineBlock2.PrecisionSawmill.name", ProgressBar.PURPLE));
 
         addRecipeCategory(registry, MachineType.ENRICHMENT_CHAMBER,
-              new MachineRecipeCategory(guiHelper, Recipe.ENRICHMENT_CHAMBER.getName(),
+              new MachineRecipeCategory(guiHelper, Recipe.ENRICHMENT_CHAMBER.getJEICategory(),
                     "tile.MachineBlock.EnrichmentChamber.name", ProgressBar.BLUE));
         addRecipeCategory(registry, MachineType.CRUSHER,
-              new MachineRecipeCategory(guiHelper, Recipe.CRUSHER.getName(), "tile.MachineBlock.Crusher.name",
+              new MachineRecipeCategory(guiHelper, Recipe.CRUSHER.getJEICategory(), "tile.MachineBlock.Crusher.name",
                     ProgressBar.CRUSH));
         addRecipeCategory(registry, MachineType.ENERGIZED_SMELTER,
-              new MachineRecipeCategory(guiHelper, Recipe.ENERGIZED_SMELTER.getName(),
+              new MachineRecipeCategory(guiHelper, Recipe.ENERGIZED_SMELTER.getJEICategory(),
                     "tile.MachineBlock.EnergizedSmelter.name", ProgressBar.BLUE));
 
         //There is no config option to disable the thermal evaporation plant

--- a/src/main/java/mekanism/client/jei/RecipeRegistryHelper.java
+++ b/src/main/java/mekanism/client/jei/RecipeRegistryHelper.java
@@ -2,8 +2,8 @@ package mekanism.client.jei;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
@@ -81,8 +81,9 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.ENRICHMENT_CHAMBER, EnrichmentRecipe.class, MachineRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiEnrichmentChamber.class, 79, 40, 24, 7, getCategory(Recipe.ENRICHMENT_CHAMBER));
-        registerRecipeItem(registry, MachineType.ENRICHMENT_CHAMBER);
+        registry.addRecipeClickArea(GuiEnrichmentChamber.class, 79, 40, 24, 7,
+              Recipe.ENRICHMENT_CHAMBER.getJEICategory());
+        registerRecipeItem(registry, MachineType.ENRICHMENT_CHAMBER, Recipe.ENRICHMENT_CHAMBER);
     }
 
     public static void registerCrusher(IModRegistry registry) {
@@ -90,8 +91,8 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.CRUSHER, CrusherRecipe.class, MachineRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiCrusher.class, 79, 40, 24, 7, getCategory(Recipe.CRUSHER));
-        registerRecipeItem(registry, MachineType.CRUSHER);
+        registry.addRecipeClickArea(GuiCrusher.class, 79, 40, 24, 7, Recipe.CRUSHER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CRUSHER, Recipe.CRUSHER);
     }
 
     public static void registerCombiner(IModRegistry registry) {
@@ -99,8 +100,8 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.COMBINER, CombinerRecipe.class, DoubleMachineRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiCombiner.class, 79, 40, 24, 7, getCategory(Recipe.COMBINER));
-        registerRecipeItem(registry, MachineType.COMBINER);
+        registry.addRecipeClickArea(GuiCombiner.class, 79, 40, 24, 7, Recipe.COMBINER.getJEICategory());
+        registerRecipeItem(registry, MachineType.COMBINER, Recipe.COMBINER);
     }
 
     public static void registerPurification(IModRegistry registry) {
@@ -109,8 +110,8 @@ public class RecipeRegistryHelper {
         }
         addRecipes(registry, Recipe.PURIFICATION_CHAMBER, PurificationRecipe.class, AdvancedMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiPurificationChamber.class, 79, 40, 24, 7,
-              getCategory(Recipe.PURIFICATION_CHAMBER));
-        registerRecipeItem(registry, MachineType.PURIFICATION_CHAMBER);
+              Recipe.PURIFICATION_CHAMBER.getJEICategory());
+        registerRecipeItem(registry, MachineType.PURIFICATION_CHAMBER, Recipe.PURIFICATION_CHAMBER);
     }
 
     public static void registerCompressor(IModRegistry registry) {
@@ -118,8 +119,9 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.OSMIUM_COMPRESSOR, OsmiumCompressorRecipe.class, AdvancedMachineRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiOsmiumCompressor.class, 79, 40, 24, 7, getCategory(Recipe.OSMIUM_COMPRESSOR));
-        registerRecipeItem(registry, MachineType.OSMIUM_COMPRESSOR);
+        registry
+              .addRecipeClickArea(GuiOsmiumCompressor.class, 79, 40, 24, 7, Recipe.OSMIUM_COMPRESSOR.getJEICategory());
+        registerRecipeItem(registry, MachineType.OSMIUM_COMPRESSOR, Recipe.OSMIUM_COMPRESSOR);
     }
 
     public static void registerInjection(IModRegistry registry) {
@@ -129,8 +131,8 @@ public class RecipeRegistryHelper {
         addRecipes(registry, Recipe.CHEMICAL_INJECTION_CHAMBER, InjectionRecipe.class,
               AdvancedMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalInjectionChamber.class, 79, 40, 24, 7,
-              getCategory(Recipe.CHEMICAL_INJECTION_CHAMBER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_INJECTION_CHAMBER);
+              Recipe.CHEMICAL_INJECTION_CHAMBER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_INJECTION_CHAMBER, Recipe.CHEMICAL_INJECTION_CHAMBER);
     }
 
     public static void registerSawmill(IModRegistry registry) {
@@ -138,8 +140,9 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.PRECISION_SAWMILL, SawmillRecipe.class, ChanceMachineRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiPrecisionSawmill.class, 79, 40, 24, 7, getCategory(Recipe.PRECISION_SAWMILL));
-        registerRecipeItem(registry, MachineType.PRECISION_SAWMILL);
+        registry
+              .addRecipeClickArea(GuiPrecisionSawmill.class, 79, 40, 24, 7, Recipe.PRECISION_SAWMILL.getJEICategory());
+        registerRecipeItem(registry, MachineType.PRECISION_SAWMILL, Recipe.PRECISION_SAWMILL);
     }
 
     public static void registerMetallurgicInfuser(IModRegistry registry) {
@@ -149,8 +152,9 @@ public class RecipeRegistryHelper {
         addRecipes(registry, Recipe.METALLURGIC_INFUSER, MetallurgicInfuserRecipe.class,
               MetallurgicInfuserRecipeWrapper::new);
         registry
-              .addRecipeClickArea(GuiMetallurgicInfuser.class, 72, 47, 32, 8, getCategory(Recipe.METALLURGIC_INFUSER));
-        registerRecipeItem(registry, MachineType.METALLURGIC_INFUSER);
+              .addRecipeClickArea(GuiMetallurgicInfuser.class, 72, 47, 32, 8,
+                    Recipe.METALLURGIC_INFUSER.getJEICategory());
+        registerRecipeItem(registry, MachineType.METALLURGIC_INFUSER, Recipe.METALLURGIC_INFUSER);
     }
 
     public static void registerCrystallizer(IModRegistry registry) {
@@ -160,8 +164,8 @@ public class RecipeRegistryHelper {
         addRecipes(registry, Recipe.CHEMICAL_CRYSTALLIZER, CrystallizerRecipe.class,
               ChemicalCrystallizerRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalCrystallizer.class, 53, 62, 48, 8,
-              getCategory(Recipe.CHEMICAL_CRYSTALLIZER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_CRYSTALLIZER);
+              Recipe.CHEMICAL_CRYSTALLIZER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_CRYSTALLIZER, Recipe.CHEMICAL_CRYSTALLIZER);
     }
 
     public static void registerDissolution(IModRegistry registry) {
@@ -171,8 +175,8 @@ public class RecipeRegistryHelper {
         addRecipes(registry, Recipe.CHEMICAL_DISSOLUTION_CHAMBER, DissolutionRecipe.class,
               ChemicalDissolutionChamberRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalDissolutionChamber.class, 64, 40, 48, 8,
-              getCategory(Recipe.CHEMICAL_DISSOLUTION_CHAMBER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_DISSOLUTION_CHAMBER);
+              Recipe.CHEMICAL_DISSOLUTION_CHAMBER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_DISSOLUTION_CHAMBER, Recipe.CHEMICAL_DISSOLUTION_CHAMBER);
     }
 
     public static void registerChemicalInfuser(IModRegistry registry) {
@@ -180,9 +184,9 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.CHEMICAL_INFUSER, ChemicalInfuserRecipe.class, ChemicalInfuserRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiChemicalInfuser.class, 47, 39, 28, 8, getCategory(Recipe.CHEMICAL_INFUSER));
-        registry.addRecipeClickArea(GuiChemicalInfuser.class, 101, 39, 28, 8, getCategory(Recipe.CHEMICAL_INFUSER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_INFUSER);
+        registry.addRecipeClickArea(GuiChemicalInfuser.class, 47, 39, 28, 8, Recipe.CHEMICAL_INFUSER.getJEICategory());
+        registry.addRecipeClickArea(GuiChemicalInfuser.class, 101, 39, 28, 8, Recipe.CHEMICAL_INFUSER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_INFUSER, Recipe.CHEMICAL_INFUSER);
     }
 
     public static void registerOxidizer(IModRegistry registry) {
@@ -190,8 +194,9 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.CHEMICAL_OXIDIZER, OxidationRecipe.class, ChemicalOxidizerRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiChemicalOxidizer.class, 64, 40, 48, 8, getCategory(Recipe.CHEMICAL_OXIDIZER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_OXIDIZER);
+        registry
+              .addRecipeClickArea(GuiChemicalOxidizer.class, 64, 40, 48, 8, Recipe.CHEMICAL_OXIDIZER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_OXIDIZER, Recipe.CHEMICAL_OXIDIZER);
     }
 
     public static void registerWasher(IModRegistry registry) {
@@ -199,8 +204,8 @@ public class RecipeRegistryHelper {
             return;
         }
         addRecipes(registry, Recipe.CHEMICAL_WASHER, WasherRecipe.class, ChemicalWasherRecipeWrapper::new);
-        registry.addRecipeClickArea(GuiChemicalWasher.class, 61, 39, 55, 8, getCategory(Recipe.CHEMICAL_WASHER));
-        registerRecipeItem(registry, MachineType.CHEMICAL_WASHER);
+        registry.addRecipeClickArea(GuiChemicalWasher.class, 61, 39, 55, 8, Recipe.CHEMICAL_WASHER.getJEICategory());
+        registerRecipeItem(registry, MachineType.CHEMICAL_WASHER, Recipe.CHEMICAL_WASHER);
     }
 
     public static void registerNeutronActivator(IModRegistry registry) {
@@ -209,8 +214,8 @@ public class RecipeRegistryHelper {
         }
         addRecipes(registry, Recipe.SOLAR_NEUTRON_ACTIVATOR, SolarNeutronRecipe.class, SolarNeutronRecipeWrapper::new);
         registry.addRecipeClickArea(GuiSolarNeutronActivator.class, 64, 39, 48, 8,
-              getCategory(Recipe.SOLAR_NEUTRON_ACTIVATOR));
-        registerRecipeItem(registry, MachineType.SOLAR_NEUTRON_ACTIVATOR);
+              Recipe.SOLAR_NEUTRON_ACTIVATOR.getJEICategory());
+        registerRecipeItem(registry, MachineType.SOLAR_NEUTRON_ACTIVATOR, Recipe.SOLAR_NEUTRON_ACTIVATOR);
     }
 
     public static void registerSeparator(IModRegistry registry) {
@@ -221,8 +226,8 @@ public class RecipeRegistryHelper {
               ElectrolyticSeparatorRecipeWrapper::new);
 
         registry.addRecipeClickArea(GuiElectrolyticSeparator.class, 80, 30, 16, 6,
-              getCategory(Recipe.ELECTROLYTIC_SEPARATOR));
-        registerRecipeItem(registry, MachineType.ELECTROLYTIC_SEPARATOR);
+              Recipe.ELECTROLYTIC_SEPARATOR.getJEICategory());
+        registerRecipeItem(registry, MachineType.ELECTROLYTIC_SEPARATOR, Recipe.ELECTROLYTIC_SEPARATOR);
     }
 
     public static void registerEvaporationPlant(IModRegistry registry) {
@@ -230,10 +235,10 @@ public class RecipeRegistryHelper {
               ThermalEvaporationRecipeWrapper::new);
 
         registry.addRecipeClickArea(GuiThermalEvaporationController.class, 49, 20, 78, 38,
-              getCategory(Recipe.THERMAL_EVAPORATION_PLANT));
+              Recipe.THERMAL_EVAPORATION_PLANT.getJEICategory());
 
         registry.addRecipeCatalyst(BasicBlockType.THERMAL_EVAPORATION_CONTROLLER.getStack(1),
-              getCategory(Recipe.THERMAL_EVAPORATION_PLANT));
+              Recipe.THERMAL_EVAPORATION_PLANT.getJEICategory());
     }
 
     public static void registerReactionChamber(IModRegistry registry) {
@@ -242,8 +247,8 @@ public class RecipeRegistryHelper {
         }
         addRecipes(registry, Recipe.PRESSURIZED_REACTION_CHAMBER, PressurizedRecipe.class, PRCRecipeWrapper::new);
 
-        registry.addRecipeClickArea(GuiPRC.class, 75, 37, 36, 10, getCategory(Recipe.PRESSURIZED_REACTION_CHAMBER));
-        registerRecipeItem(registry, MachineType.PRESSURIZED_REACTION_CHAMBER);
+        registry.addRecipeClickArea(GuiPRC.class, 75, 37, 36, 10, Recipe.PRESSURIZED_REACTION_CHAMBER.getJEICategory());
+        registerRecipeItem(registry, MachineType.PRESSURIZED_REACTION_CHAMBER, Recipe.PRESSURIZED_REACTION_CHAMBER);
     }
 
     public static void registerCondensentrator(IModRegistry registry) {
@@ -272,7 +277,8 @@ public class RecipeRegistryHelper {
         if (!MachineType.ENERGIZED_SMELTER.isEnabled()) {
             return;
         }
-        registry.handleRecipes(SmeltingRecipe.class, MachineRecipeWrapper::new, getCategory(Recipe.ENERGIZED_SMELTER));
+        registry.handleRecipes(SmeltingRecipe.class, MachineRecipeWrapper::new,
+              Recipe.ENERGIZED_SMELTER.getJEICategory());
 
         boolean crafttweakerLoaded = Loader.isModLoaded("crafttweaker");
 
@@ -281,29 +287,30 @@ public class RecipeRegistryHelper {
             // Add all recipes
             Collection<SmeltingRecipe> recipeList = Recipe.ENERGIZED_SMELTER.get().values();
             registry.addRecipes(recipeList.stream().map(MachineRecipeWrapper::new).collect(Collectors.toList()),
-                  getCategory(Recipe.ENERGIZED_SMELTER));
+                  Recipe.ENERGIZED_SMELTER.getJEICategory());
 
             registry
-                  .addRecipeClickArea(GuiEnergizedSmelter.class, 79, 40, 24, 7, getCategory(Recipe.ENERGIZED_SMELTER));
+                  .addRecipeClickArea(GuiEnergizedSmelter.class, 79, 40, 24, 7,
+                        Recipe.ENERGIZED_SMELTER.getJEICategory());
         } else if (crafttweakerLoaded && EnergizedSmelter.hasAddedRecipe()) // Added but not removed
         {
             // Only add added recipes
-            HashMap<ItemStackInput, SmeltingRecipe> smeltingRecipes = Recipe.ENERGIZED_SMELTER.get();
+            Map<ItemStackInput, SmeltingRecipe> smeltingRecipes = Recipe.ENERGIZED_SMELTER.get();
             List<MachineRecipeWrapper> smeltingWrapper = smeltingRecipes.entrySet().stream()
                   .filter(entry -> !FurnaceRecipes.instance().getSmeltingList().keySet()
                         .contains(entry.getKey().ingredient)).map(entry -> new MachineRecipeWrapper(entry.getValue()))
                   .collect(Collectors.toList());
-            registry.addRecipes(smeltingWrapper, getCategory(Recipe.ENERGIZED_SMELTER));
+            registry.addRecipes(smeltingWrapper, Recipe.ENERGIZED_SMELTER.getJEICategory());
 
             registry.addRecipeClickArea(GuiEnergizedSmelter.class, 79, 40, 24, 7, VanillaRecipeCategoryUid.SMELTING,
-                  getCategory(Recipe.ENERGIZED_SMELTER));
+                  Recipe.ENERGIZED_SMELTER.getJEICategory());
             registerVanillaSmeltingRecipeCatalyst(registry);
         } else {
             //Only use furnace list, so no extra registration.
             registry.addRecipeClickArea(GuiEnergizedSmelter.class, 79, 40, 24, 7, VanillaRecipeCategoryUid.SMELTING);
             registerVanillaSmeltingRecipeCatalyst(registry);
         }
-        registerRecipeItem(registry, MachineType.ENERGIZED_SMELTER);
+        registerRecipeItem(registry, MachineType.ENERGIZED_SMELTER, Recipe.ENERGIZED_SMELTER);
     }
 
 
@@ -329,20 +336,15 @@ public class RecipeRegistryHelper {
 
     private static <T> void addRecipes(IModRegistry registry, Recipe type, Class<T> recipeClass,
           IRecipeWrapperFactory<T> factory) {
-        String recipeCategoryUid = getCategory(type);
+        String recipeCategoryUid = type.getJEICategory();
         registry.handleRecipes(recipeClass, factory, recipeCategoryUid);
         Collection<T> recipeList = type.get().values();
         registry.addRecipes(recipeList.stream().map(factory::getRecipeWrapper).collect(Collectors.toList()),
               recipeCategoryUid);
     }
 
-    private static String getCategory(Recipe type) {
-        return "mekanism." + type.getName();
-    }
-
-    private static void registerRecipeItem(IModRegistry registry, MachineType type) {
-        String category = "mekanism." + type.getName();
-        registry.addRecipeCatalyst(type.getStack(), category);
+    private static void registerRecipeItem(IModRegistry registry, MachineType type, Recipe recipe) {
+        registry.addRecipeCatalyst(type.getStack(), recipe.getJEICategory());
         RecipeType factoryType = null;
         for (RecipeType t : RecipeType.values()) {
             if (t.getType() == type) {
@@ -353,7 +355,7 @@ public class RecipeRegistryHelper {
         if (factoryType != null) {
             for (Tier.FactoryTier tier : Tier.FactoryTier.values()) {
                 if (tier.machineType.isEnabled()) {
-                    registry.addRecipeCatalyst(MekanismUtils.getFactory(tier, factoryType), category);
+                    registry.addRecipeCatalyst(MekanismUtils.getFactory(tier, factoryType), recipe.getJEICategory());
                 }
             }
         }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeCategory.java
@@ -3,6 +3,7 @@ package mekanism.client.jei.machine.chemical;
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
@@ -15,7 +16,7 @@ import net.minecraft.client.Minecraft;
 public class ChemicalCrystallizerRecipeCategory extends BaseRecipeCategory {
 
     public ChemicalCrystallizerRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiChemicalCrystallizer.png", "chemical_crystallizer",
+        super(helper, "mekanism:gui/nei/GuiChemicalCrystallizer.png", Recipe.CHEMICAL_CRYSTALLIZER.getJEICategory(),
               "tile.MachineBlock2.ChemicalCrystallizer.name", null, 5, 3, 147, 79);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeCategory.java
@@ -4,6 +4,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
 import mekanism.common.MekanismFluids;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.DissolutionRecipe;
 import mekanism.common.tile.TileEntityChemicalDissolutionChamber;
 import mezz.jei.api.IGuiHelper;
@@ -17,8 +18,9 @@ import net.minecraft.client.Minecraft;
 public class ChemicalDissolutionChamberRecipeCategory extends BaseRecipeCategory {
 
     public ChemicalDissolutionChamberRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiChemicalDissolutionChamber.png", "chemical_dissolution_chamber",
-              "gui.chemicalDissolutionChamber.short", null, 3, 3, 170, 79);
+        super(helper, "mekanism:gui/nei/GuiChemicalDissolutionChamber.png",
+              Recipe.CHEMICAL_DISSOLUTION_CHAMBER.getJEICategory(), "gui.chemicalDissolutionChamber.short", null, 3, 3,
+              170, 79);
     }
 
     @Override

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeCategory.java
@@ -3,6 +3,7 @@ package mekanism.client.jei.machine.chemical;
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
@@ -14,7 +15,7 @@ import net.minecraft.client.Minecraft;
 public class ChemicalInfuserRecipeCategory extends BaseRecipeCategory {
 
     public ChemicalInfuserRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiChemicalInfuser.png", "chemical_infuser",
+        super(helper, "mekanism:gui/nei/GuiChemicalInfuser.png", Recipe.CHEMICAL_INFUSER.getJEICategory(),
               "tile.MachineBlock2.ChemicalInfuser.name", null, 3, 3, 170, 80);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeCategory.java
@@ -10,6 +10,7 @@ import mekanism.client.gui.element.GuiSlot;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.OxidationRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
@@ -21,7 +22,7 @@ import mezz.jei.api.recipe.IRecipeWrapper;
 public class ChemicalOxidizerRecipeCategory extends BaseRecipeCategory {
 
     public ChemicalOxidizerRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/GuiChemicalOxidizer.png", "chemical_oxidizer",
+        super(helper, "mekanism:gui/GuiChemicalOxidizer.png", Recipe.CHEMICAL_OXIDIZER.getJEICategory(),
               "tile.MachineBlock2.ChemicalOxidizer.name", ProgressBar.LARGE_RIGHT, 20, 12, 132, 62);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeCategory.java
@@ -3,6 +3,7 @@ package mekanism.client.jei.machine.chemical;
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.WasherRecipe;
 import mekanism.common.tile.TileEntityChemicalWasher;
 import mezz.jei.api.IGuiHelper;
@@ -17,7 +18,7 @@ import net.minecraft.client.Minecraft;
 public class ChemicalWasherRecipeCategory extends BaseRecipeCategory {
 
     public ChemicalWasherRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiChemicalWasher.png", "chemical_washer",
+        super(helper, "mekanism:gui/nei/GuiChemicalWasher.png", Recipe.CHEMICAL_WASHER.getJEICategory(),
               "tile.MachineBlock2.ChemicalWasher.name", null, 3, 3, 170, 70);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeCategory.java
@@ -14,6 +14,7 @@ import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.SeparatorRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -26,7 +27,7 @@ import mezz.jei.api.recipe.IRecipeWrapper;
 public class ElectrolyticSeparatorRecipeCategory extends BaseRecipeCategory {
 
     public ElectrolyticSeparatorRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/GuiElectrolyticSeparator.png", "electrolytic_separator",
+        super(helper, "mekanism:gui/GuiElectrolyticSeparator.png", Recipe.ELECTROLYTIC_SEPARATOR.getJEICategory(),
               "tile.MachineBlock2.ElectrolyticSeparator.name", ProgressBar.BI, 4, 9, 167, 62);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeCategory.java
@@ -14,6 +14,7 @@ import mekanism.client.gui.element.GuiSlot;
 import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.MetallurgicInfuserRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
@@ -25,7 +26,7 @@ import net.minecraft.item.ItemStack;
 public class MetallurgicInfuserRecipeCategory extends BaseRecipeCategory {
 
     public MetallurgicInfuserRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/GuiMetallurgicInfuser.png", "metallurgic_infuser",
+        super(helper, "mekanism:gui/GuiMetallurgicInfuser.png", Recipe.METALLURGIC_INFUSER.getJEICategory(),
               "tile.MachineBlock.MetallurgicInfuser.name", ProgressBar.MEDIUM, 5, 16, 166, 54);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/other/PRCRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/PRCRecipeCategory.java
@@ -14,6 +14,7 @@ import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.PressurizedRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -26,7 +27,7 @@ import mezz.jei.api.recipe.IRecipeWrapper;
 public class PRCRecipeCategory extends BaseRecipeCategory {
 
     public PRCRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiPRC.png", "pressurized_reaction_chamber",
+        super(helper, "mekanism:gui/nei/GuiPRC.png", Recipe.PRESSURIZED_REACTION_CHAMBER.getJEICategory(),
               "tile.MachineBlock2.PressurizedReactionChamber.short.name", ProgressBar.MEDIUM, 3, 11, 170, 68);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/other/RotaryCondensentratorRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/RotaryCondensentratorRecipeCategory.java
@@ -18,8 +18,8 @@ public class RotaryCondensentratorRecipeCategory extends BaseRecipeCategory {
 
     public RotaryCondensentratorRecipeCategory(IGuiHelper helper, boolean condensentrating) {
         super(helper, "mekanism:gui/nei/GuiRotaryCondensentrator.png",
-              condensentrating ? "rotary_condensentrator_condensentrating"
-                    : "rotary_condensentrator_decondensentrating",
+              condensentrating ? "mekanism.rotary_condensentrator_condensentrating"
+                    : "mekanism.rotary_condensentrator_decondensentrating",
               condensentrating ? "gui.condensentrating" : "gui.decondensentrating", null, 3, 12, 170, 71);
         this.condensentrating = condensentrating;
     }

--- a/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeCategory.java
@@ -3,6 +3,7 @@ package mekanism.client.jei.machine.other;
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.SolarNeutronRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
@@ -14,7 +15,7 @@ import net.minecraft.client.Minecraft;
 public class SolarNeutronRecipeCategory extends BaseRecipeCategory {
 
     public SolarNeutronRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiSolarNeutronActivator.png", "solar_neutron_activator",
+        super(helper, "mekanism:gui/nei/GuiSolarNeutronActivator.png", Recipe.SOLAR_NEUTRON_ACTIVATOR.getJEICategory(),
               "tile.MachineBlock3.SolarNeutronActivator.name", null, 3, 12, 170, 70);
     }
 

--- a/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeCategory.java
@@ -1,6 +1,7 @@
 package mekanism.client.jei.machine.other;
 
 import mekanism.client.jei.BaseRecipeCategory;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.machines.ThermalEvaporationRecipe;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -12,8 +13,9 @@ import net.minecraft.client.Minecraft;
 public class ThermalEvaporationRecipeCategory extends BaseRecipeCategory {
 
     public ThermalEvaporationRecipeCategory(IGuiHelper helper) {
-        super(helper, "mekanism:gui/nei/GuiThermalEvaporationController.png", "thermal_evaporation_plant",
-              "gui.thermalEvaporationController.short", null, 3, 12, 170, 62);
+        super(helper, "mekanism:gui/nei/GuiThermalEvaporationController.png",
+              Recipe.THERMAL_EVAPORATION_PLANT.getJEICategory(), "gui.thermalEvaporationController.short", null, 3, 12,
+              170, 62);
     }
 
     @Override

--- a/src/main/java/mekanism/common/base/IFactory.java
+++ b/src/main/java/mekanism/common/base/IFactory.java
@@ -2,6 +2,7 @@ package mekanism.common.base;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.common.InfuseStorage;
@@ -146,12 +147,10 @@ public interface IFactory {
                 if (infuse.type != null) {
                     return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(infuse, slotStack));
                 } else {
-                    for (Object obj : Recipe.METALLURGIC_INFUSER.get().entrySet()) {
-                        Map.Entry entry = (Map.Entry) obj;
-                        InfusionInput input = (InfusionInput) entry.getKey();
-
-                        if (input.inputStack.isItemEqual(slotStack)) {
-                            return (MetallurgicInfuserRecipe) entry.getValue();
+                    for (Entry<InfusionInput, MetallurgicInfuserRecipe> entry : Recipe.METALLURGIC_INFUSER.get()
+                          .entrySet()) {
+                        if (entry.getKey().inputStack.isItemEqual(slotStack)) {
+                            return entry.getValue();
                         }
                     }
                 }

--- a/src/main/java/mekanism/common/integration/IMCHandler.java
+++ b/src/main/java/mekanism/common/integration/IMCHandler.java
@@ -33,7 +33,8 @@ public class IMCHandler {
                 }
 
                 for (Recipe type : Recipe.values()) {
-                    if (message.equalsIgnoreCase(type.getRecipeName() + "Recipe")) {
+                    if (message.equalsIgnoreCase(type.getRecipeName() + "Recipe") ||
+                          message.equalsIgnoreCase(type.getOldRecipeName() + "Recipe")) {
                         MachineInput input = type.createInput(msg.getNBTValue());
 
                         if (input != null && input.isValid()) {

--- a/src/main/java/mekanism/common/integration/crafttweaker/commands/MekRecipesCommand.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/commands/MekRecipesCommand.java
@@ -4,7 +4,6 @@ import crafttweaker.CraftTweakerAPI;
 import crafttweaker.mc1120.commands.CraftTweakerCommand;
 import crafttweaker.mc1120.commands.SpecialMessagesChat;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -64,248 +63,196 @@ public class MekRecipesCommand extends CraftTweakerCommand {
         }
         String subCommand = args[0];
         CraftTweakerAPI.logCommand(subCommand + ":");
-        Collection values = Collections.emptyList();
+        Recipe type;
         switch (subCommand) {
             case "crystallizer":
-                values = Recipe.CHEMICAL_CRYSTALLIZER.get().values();
-                for (Object value : values) {
-                    if (value instanceof CrystallizerRecipe) {
-                        CrystallizerRecipe recipe = ((CrystallizerRecipe) value);
-                        CraftTweakerAPI
-                              .logCommand(String.format("mods.mekanism.chemical.crystallizer.addRecipe(%s, %s)",
-                                    RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
-                                    RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                              ));
-                    }
+                type = Recipe.CHEMICAL_CRYSTALLIZER;
+                for (CrystallizerRecipe recipe : Recipe.CHEMICAL_CRYSTALLIZER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.crystallizer.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "dissolution":
-                values = Recipe.CHEMICAL_DISSOLUTION_CHAMBER.get().values();
-                for (Object value : values) {
-                    if (value instanceof DissolutionRecipe) {
-                        DissolutionRecipe recipe = (DissolutionRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.dissolution.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getGasName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.CHEMICAL_DISSOLUTION_CHAMBER;
+                for (DissolutionRecipe recipe : Recipe.CHEMICAL_DISSOLUTION_CHAMBER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.dissolution.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "chemicalInfuser":
-                values = Recipe.METALLURGIC_INFUSER.get().values();
-                for (Object value : values) {
-                    if (value instanceof ChemicalInfuserRecipe) {
-                        ChemicalInfuserRecipe recipe = (ChemicalInfuserRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.infuser.addRecipe(%s, %s, %s)",
-                              RecipeInfoHelper.getGasName(recipe.getInput().leftGas),
-                              RecipeInfoHelper.getGasName(recipe.getInput().rightGas),
-                              RecipeInfoHelper.getGasName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.CHEMICAL_INFUSER;
+                for (ChemicalInfuserRecipe recipe : Recipe.CHEMICAL_INFUSER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.infuser.addRecipe(%s, %s, %s)",
+                          RecipeInfoHelper.getGasName(recipe.getInput().leftGas),
+                          RecipeInfoHelper.getGasName(recipe.getInput().rightGas),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "injection":
-                values = Recipe.CHEMICAL_INJECTION_CHAMBER.get().values();
-                for (Object value : values) {
-                    if (value instanceof InjectionRecipe) {
-                        InjectionRecipe recipe = (InjectionRecipe) value;
-                        CraftTweakerAPI
-                              .logCommand(String.format("mods.mekanism.chemical.injection.addRecipe(%s, %s, %s)",
-                                    RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
-                                    RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                                    RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                              ));
-                    }
+                type = Recipe.CHEMICAL_INJECTION_CHAMBER;
+                for (InjectionRecipe recipe : Recipe.CHEMICAL_INJECTION_CHAMBER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.injection.addRecipe(%s, %s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
+                          RecipeInfoHelper.getGasName(recipe.getInput().gasType),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "oxidizer":
-                values = Recipe.CHEMICAL_OXIDIZER.get().values();
-                for (Object value : values) {
-                    if (value instanceof OxidationRecipe) {
-                        OxidationRecipe recipe = (OxidationRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.oxidizer.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getGasName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.CHEMICAL_OXIDIZER;
+                for (OxidationRecipe recipe : Recipe.CHEMICAL_OXIDIZER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.oxidizer.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "washer":
-                values = Recipe.CHEMICAL_WASHER.get().values();
-                for (Object value : values) {
-                    if (value instanceof WasherRecipe) {
-                        WasherRecipe recipe = (WasherRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.washer.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getGasName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.CHEMICAL_WASHER;
+                for (WasherRecipe recipe : Recipe.CHEMICAL_WASHER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.chemical.washer.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "combiner":
-                values = Recipe.COMBINER.get().values();
-                for (Object value : values) {
-                    if (value instanceof CombinerRecipe) {
-                        CombinerRecipe recipe = (CombinerRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.combiner.addRecipe(%s, %s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
-                              RecipeInfoHelper.getItemName(recipe.getInput().extraStack),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.COMBINER;
+                for (CombinerRecipe recipe : Recipe.COMBINER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.combiner.addRecipe(%s, %s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
+                          RecipeInfoHelper.getItemName(recipe.getInput().extraStack),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "crusher":
-                values = Recipe.CRUSHER.get().values();
-                for (Object value : values) {
-                    if (value instanceof CrusherRecipe) {
-                        CrusherRecipe recipe = (CrusherRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.crusher.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.CRUSHER;
+                for (CrusherRecipe recipe : Recipe.CRUSHER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.crusher.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "separator":
-                values = Recipe.ELECTROLYTIC_SEPARATOR.get().values();
-                for (Object value : values) {
-                    if (value instanceof SeparatorRecipe) {
-                        SeparatorRecipe recipe = (SeparatorRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.separator.addRecipe(%s, %s, %s, %s)",
-                              RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
-                              recipe.energyUsage,
-                              RecipeInfoHelper.getGasName(recipe.getOutput().leftGas),
-                              RecipeInfoHelper.getGasName(recipe.getOutput().rightGas)
-                        ));
-                    }
+                type = Recipe.ELECTROLYTIC_SEPARATOR;
+                for (SeparatorRecipe recipe : Recipe.ELECTROLYTIC_SEPARATOR.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.separator.addRecipe(%s, %s, %s, %s)",
+                          RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
+                          recipe.energyUsage,
+                          RecipeInfoHelper.getGasName(recipe.getOutput().leftGas),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().rightGas)
+                    ));
                 }
                 break;
             case "smelter":
-                values = Recipe.ENERGIZED_SMELTER.get().values();
-                for (Object value : values) {
-                    if (value instanceof SmeltingRecipe) {
-                        SmeltingRecipe recipe = (SmeltingRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.smelter.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.ENERGIZED_SMELTER;
+                for (SmeltingRecipe recipe : Recipe.ENERGIZED_SMELTER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.smelter.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "enrichment":
-                values = Recipe.ENRICHMENT_CHAMBER.get().values();
-                for (Object value : values) {
-                    if (value instanceof EnrichmentRecipe) {
-                        EnrichmentRecipe recipe = (EnrichmentRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.enrichment.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.ENRICHMENT_CHAMBER;
+                for (EnrichmentRecipe recipe : Recipe.ENRICHMENT_CHAMBER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.enrichment.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "metallurgicInfuser":
-                values = Recipe.METALLURGIC_INFUSER.get().values();
-                for (Object value : values) {
-                    if (value instanceof MetallurgicInfuserRecipe) {
-                        MetallurgicInfuserRecipe recipe = (MetallurgicInfuserRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.infuser.addRecipe(%s, %s, %s, %s)",
-                              recipe.getInput().infuse.type,
-                              recipe.getInput().infuse.amount,
-                              RecipeInfoHelper.getItemName(recipe.getInput().inputStack),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.METALLURGIC_INFUSER;
+                for (MetallurgicInfuserRecipe recipe : Recipe.METALLURGIC_INFUSER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.infuser.addRecipe(%s, %s, %s, %s)",
+                          recipe.getInput().infuse.type,
+                          recipe.getInput().infuse.amount,
+                          RecipeInfoHelper.getItemName(recipe.getInput().inputStack),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "compressor":
-                values = Recipe.OSMIUM_COMPRESSOR.get().values();
-                for (Object value : values) {
-                    if (value instanceof OsmiumCompressorRecipe) {
-                        OsmiumCompressorRecipe recipe = (OsmiumCompressorRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.compressor.addRecipe(%s, %s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
-                              RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.OSMIUM_COMPRESSOR;
+                for (OsmiumCompressorRecipe recipe : Recipe.OSMIUM_COMPRESSOR.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.compressor.addRecipe(%s, %s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
+                          RecipeInfoHelper.getGasName(recipe.getInput().gasType),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "sawmill":
-                values = Recipe.PRECISION_SAWMILL.get().values();
-                for (Object value : values) {
-                    if (value instanceof SawmillRecipe) {
-                        SawmillRecipe recipe = (SawmillRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.sawmill.addRecipe(%s, %s, %s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().primaryOutput),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().secondaryOutput),
-                              recipe.getOutput().secondaryChance
-                        ));
-                    }
+                type = Recipe.PRECISION_SAWMILL;
+                for (SawmillRecipe recipe : Recipe.PRECISION_SAWMILL.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.sawmill.addRecipe(%s, %s, %s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().primaryOutput),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().secondaryOutput),
+                          recipe.getOutput().secondaryChance
+                    ));
                 }
                 break;
             case "prc":
-                values = Recipe.PRESSURIZED_REACTION_CHAMBER.get().values();
-                for (Object value : values) {
-                    if (value instanceof PressurizedRecipe) {
-                        PressurizedRecipe recipe = (PressurizedRecipe) value;
-                        CraftTweakerAPI
-                              .logCommand(String.format("mods.mekanism.reaction.addRecipe(%s, %s, %s, %s, %s, %s, %s)",
-                                    RecipeInfoHelper.getItemName(recipe.getInput().getSolid()),
-                                    RecipeInfoHelper.getFluidName(recipe.getInput().getFluid()),
-                                    RecipeInfoHelper.getGasName(recipe.getInput().getGas()),
-                                    RecipeInfoHelper.getItemName(recipe.getOutput().getItemOutput()),
-                                    RecipeInfoHelper.getGasName(recipe.getOutput().getGasOutput()),
-                                    recipe.extraEnergy,
-                                    recipe.ticks
-                              ));
-                    }
+                type = Recipe.PRESSURIZED_REACTION_CHAMBER;
+                for (PressurizedRecipe recipe : Recipe.PRESSURIZED_REACTION_CHAMBER.get().values()) {
+                    CraftTweakerAPI
+                          .logCommand(String.format("mods.mekanism.reaction.addRecipe(%s, %s, %s, %s, %s, %s, %s)",
+                                RecipeInfoHelper.getItemName(recipe.getInput().getSolid()),
+                                RecipeInfoHelper.getFluidName(recipe.getInput().getFluid()),
+                                RecipeInfoHelper.getGasName(recipe.getInput().getGas()),
+                                RecipeInfoHelper.getItemName(recipe.getOutput().getItemOutput()),
+                                RecipeInfoHelper.getGasName(recipe.getOutput().getGasOutput()),
+                                recipe.extraEnergy,
+                                recipe.ticks
+                          ));
                 }
                 break;
             case "purification":
-                values = Recipe.PURIFICATION_CHAMBER.get().values();
-                for (Object value : values) {
-                    if (value instanceof PurificationRecipe) {
-                        PurificationRecipe recipe = (PurificationRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.purification.addRecipe(%s, %s, %s)",
-                              RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
-                              RecipeInfoHelper.getGasName(recipe.getInput().gasType),
-                              RecipeInfoHelper.getItemName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.PURIFICATION_CHAMBER;
+                for (PurificationRecipe recipe : Recipe.PURIFICATION_CHAMBER.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.purification.addRecipe(%s, %s, %s)",
+                          RecipeInfoHelper.getItemName(recipe.getInput().itemStack),
+                          RecipeInfoHelper.getGasName(recipe.getInput().gasType),
+                          RecipeInfoHelper.getItemName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "solarneutronactivator":
-                values = Recipe.SOLAR_NEUTRON_ACTIVATOR.get().values();
-                for (Object value : values) {
-                    if (value instanceof SolarNeutronRecipe) {
-                        SolarNeutronRecipe recipe = (SolarNeutronRecipe) value;
-                        CraftTweakerAPI
-                              .logCommand(String.format("mods.mekanism.solarneutronactivator.addRecipe(%s, %s)",
-                                    RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
-                                    RecipeInfoHelper.getGasName(recipe.getOutput().output)
-                              ));
-                    }
+                type = Recipe.SOLAR_NEUTRON_ACTIVATOR;
+                for (SolarNeutronRecipe recipe : Recipe.SOLAR_NEUTRON_ACTIVATOR.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.solarneutronactivator.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getGasName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getGasName(recipe.getOutput().output)
+                    ));
                 }
                 break;
             case "thermalevaporation":
-                values = Recipe.THERMAL_EVAPORATION_PLANT.get().values();
-                for (Object value : values) {
-                    if (value instanceof ThermalEvaporationRecipe) {
-                        ThermalEvaporationRecipe recipe = (ThermalEvaporationRecipe) value;
-                        CraftTweakerAPI.logCommand(String.format("mods.mekanism.thermalevaporation.addRecipe(%s, %s)",
-                              RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
-                              RecipeInfoHelper.getFluidName(recipe.getOutput().output)
-                        ));
-                    }
+                type = Recipe.THERMAL_EVAPORATION_PLANT;
+                for (ThermalEvaporationRecipe recipe : Recipe.THERMAL_EVAPORATION_PLANT.get().values()) {
+                    CraftTweakerAPI.logCommand(String.format("mods.mekanism.thermalevaporation.addRecipe(%s, %s)",
+                          RecipeInfoHelper.getFluidName(recipe.getInput().ingredient),
+                          RecipeInfoHelper.getFluidName(recipe.getOutput().output)
+                    ));
                 }
                 break;
+            default:
+                sender.sendMessage(SpecialMessagesChat.getNormalMessage(
+                      "Recipe Type required, pick one of the following: " + Arrays.toString(subCommands.toArray())));
+                return;
         }
 
         sender.sendMessage(SpecialMessagesChat
-              .getLinkToCraftTweakerLog("List of " + values.size() + " " + subCommand + " recipes generated;", sender));
+              .getLinkToCraftTweakerLog("List of " + type.get().size() + " " + subCommand + " recipes generated;",
+                    sender));
     }
 
     @Override

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalCrystallizer.java
@@ -13,9 +13,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -30,7 +28,7 @@ public class ChemicalCrystallizer {
     public static void addRecipe(IGasStack gasInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_CRYSTALLIZER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_CRYSTALLIZER,
                         new CrystallizerRecipe(GasHelper.toGas(gasInput), IngredientHelper.toStack(itemOutput))));
         }
     }
@@ -39,15 +37,13 @@ public class ChemicalCrystallizer {
     public static void removeRecipe(IIngredient itemOutput, @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<GasInput, ItemStackOutput, CrystallizerRecipe>(NAME,
-                        Recipe.CHEMICAL_CRYSTALLIZER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_CRYSTALLIZER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<CrystallizerRecipe>(NAME, Recipe.CHEMICAL_CRYSTALLIZER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_CRYSTALLIZER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalDissolution.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalDissolution.java
@@ -13,9 +13,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.DissolutionRecipe;
-import mekanism.common.recipe.outputs.GasOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -30,7 +28,7 @@ public class ChemicalDissolution {
     public static void addRecipe(IItemStack itemInput, IGasStack gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER,
                         new DissolutionRecipe(IngredientHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
         }
     }
@@ -39,15 +37,14 @@ public class ChemicalDissolution {
     public static void removeRecipe(IIngredient gasOutput, @Optional IIngredient itemInput) {
         if (IngredientHelper.checkNotNull(NAME, gasOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, GasOutput, DissolutionRecipe>(NAME,
-                        Recipe.CHEMICAL_DISSOLUTION_CHAMBER, new IngredientWrapper(gasOutput),
-                        new IngredientWrapper(itemInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER,
+                        new IngredientWrapper(gasOutput), new IngredientWrapper(itemInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
         CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<DissolutionRecipe>(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER));
+              .add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_DISSOLUTION_CHAMBER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInfuser.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInfuser.java
@@ -12,9 +12,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ChemicalPairInput;
 import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
-import mekanism.common.recipe.outputs.GasOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -29,7 +27,7 @@ public class ChemicalInfuser {
     public static void addRecipe(IGasStack leftGasInput, IGasStack rightGasInput, IGasStack gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, leftGasInput, rightGasInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_INFUSER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_INFUSER,
                         new ChemicalInfuserRecipe(GasHelper.toGas(leftGasInput), GasHelper.toGas(rightGasInput),
                               GasHelper.toGas(gasOutput))));
         }
@@ -40,15 +38,13 @@ public class ChemicalInfuser {
           @Optional IIngredient rightGasInput) {
         if (IngredientHelper.checkNotNull(NAME, gasOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ChemicalPairInput, GasOutput, ChemicalInfuserRecipe>(NAME,
-                        Recipe.CHEMICAL_INFUSER, new IngredientWrapper(gasOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_INFUSER, new IngredientWrapper(gasOutput),
                         new IngredientWrapper(leftGasInput, rightGasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<ChemicalInfuserRecipe>(NAME, Recipe.CHEMICAL_INFUSER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_INFUSER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInjection.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalInjection.java
@@ -30,7 +30,7 @@ public class ChemicalInjection {
     public static void addRecipe(IItemStack itemInput, IGasStack gasInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER,
                         new InjectionRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
                               new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
@@ -42,15 +42,14 @@ public class ChemicalInjection {
           @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<AdvancedMachineInput, ItemStackOutput, InjectionRecipe>(NAME,
-                        Recipe.CHEMICAL_INJECTION_CHAMBER, new IngredientWrapper(itemOutput),
-                        new IngredientWrapper(itemInput, gasInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER,
+                        new IngredientWrapper(itemOutput), new IngredientWrapper(itemInput, gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
         CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<InjectionRecipe>(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER));
+              .add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_INJECTION_CHAMBER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalOxidizer.java
@@ -13,9 +13,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.OxidationRecipe;
-import mekanism.common.recipe.outputs.GasOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -30,7 +28,7 @@ public class ChemicalOxidizer {
     public static void addRecipe(IItemStack itemInput, IGasStack gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_OXIDIZER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_OXIDIZER,
                         new OxidationRecipe(IngredientHelper.toStack(itemInput), GasHelper.toGas(gasOutput))));
         }
     }
@@ -39,14 +37,13 @@ public class ChemicalOxidizer {
     public static void removeRecipe(IIngredient gasOutput, @Optional IIngredient itemInput) {
         if (IngredientHelper.checkNotNull(NAME, gasOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, GasOutput, OxidationRecipe>(NAME,
-                        Recipe.CHEMICAL_OXIDIZER, new IngredientWrapper(gasOutput), new IngredientWrapper(itemInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_OXIDIZER, new IngredientWrapper(gasOutput),
+                        new IngredientWrapper(itemInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<OxidationRecipe>(NAME, Recipe.CHEMICAL_OXIDIZER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_OXIDIZER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalWasher.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ChemicalWasher.java
@@ -12,9 +12,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.WasherRecipe;
-import mekanism.common.recipe.outputs.GasOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -28,7 +26,7 @@ public class ChemicalWasher {
     @ZenMethod
     public static void addRecipe(IGasStack gasInput, IGasStack gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, gasInput, gasOutput)) {
-            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.CHEMICAL_WASHER,
+            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe<>(NAME, Recipe.CHEMICAL_WASHER,
                   new WasherRecipe(GasHelper.toGas(gasInput), GasHelper.toGas(gasOutput))));
         }
     }
@@ -36,14 +34,14 @@ public class ChemicalWasher {
     @ZenMethod
     public static void removeRecipe(IIngredient gasOutput, @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, gasOutput)) {
-            CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveMekanismRecipe<GasInput, GasOutput, WasherRecipe>(NAME,
-                  Recipe.CHEMICAL_WASHER, new IngredientWrapper(gasOutput), new IngredientWrapper(gasInput)));
+            CrafttweakerIntegration.LATE_REMOVALS
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CHEMICAL_WASHER, new IngredientWrapper(gasOutput),
+                        new IngredientWrapper(gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<WasherRecipe>(NAME, Recipe.CHEMICAL_WASHER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_WASHER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
@@ -27,9 +27,11 @@ public class Combiner {
     @ZenMethod
     public static void addRecipe(IItemStack itemInput, IItemStack extraInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, extraInput, itemOutput)) {
-            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.COMBINER, new CombinerRecipe(
-                  new DoubleMachineInput(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(extraInput)),
-                  new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
+            CrafttweakerIntegration.LATE_ADDITIONS
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.COMBINER, new CombinerRecipe(
+                        new DoubleMachineInput(IngredientHelper.toStack(itemInput),
+                              IngredientHelper.toStack(extraInput)),
+                        new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
         }
     }
 
@@ -41,7 +43,7 @@ public class Combiner {
     @Deprecated
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
-            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.COMBINER,
+            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe<>(NAME, Recipe.COMBINER,
                   new CombinerRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
         }
     }
@@ -51,14 +53,13 @@ public class Combiner {
           @Optional IIngredient extraInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<DoubleMachineInput, ItemStackOutput, CombinerRecipe>(NAME,
-                        Recipe.COMBINER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.COMBINER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput, extraInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<CombinerRecipe>(NAME, Recipe.COMBINER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.COMBINER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Compressor.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Compressor.java
@@ -30,7 +30,7 @@ public class Compressor {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.OSMIUM_COMPRESSOR,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.OSMIUM_COMPRESSOR,
                         new OsmiumCompressorRecipe(IngredientHelper.toStack(itemInput),
                               IngredientHelper.toStack(itemOutput))));
         }
@@ -40,7 +40,7 @@ public class Compressor {
     public static void addRecipe(IItemStack itemInput, IGasStack gasInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.OSMIUM_COMPRESSOR,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.OSMIUM_COMPRESSOR,
                         new OsmiumCompressorRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
                               new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
@@ -52,15 +52,13 @@ public class Compressor {
           @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<AdvancedMachineInput, ItemStackOutput, OsmiumCompressorRecipe>(NAME,
-                        Recipe.OSMIUM_COMPRESSOR, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.OSMIUM_COMPRESSOR, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput, gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<OsmiumCompressorRecipe>(NAME, Recipe.OSMIUM_COMPRESSOR));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.OSMIUM_COMPRESSOR));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Crusher.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Crusher.java
@@ -11,9 +11,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.CrusherRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -27,7 +25,7 @@ public class Crusher {
     @ZenMethod
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
-            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, Recipe.CRUSHER,
+            CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe<>(NAME, Recipe.CRUSHER,
                   new CrusherRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
         }
     }
@@ -36,14 +34,13 @@ public class Crusher {
     public static void removeRecipe(IIngredient itemOutput, @Optional IIngredient itemInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, ItemStackOutput, CrusherRecipe>(NAME,
-                        Recipe.CRUSHER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.CRUSHER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<CrusherRecipe>(NAME, Recipe.CRUSHER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CRUSHER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/EnergizedSmelter.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/EnergizedSmelter.java
@@ -11,9 +11,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.SmeltingRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -38,7 +36,7 @@ public class EnergizedSmelter {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.ENERGIZED_SMELTER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.ENERGIZED_SMELTER,
                         new SmeltingRecipe(IngredientHelper.toStack(itemInput), IngredientHelper.toStack(itemOutput))));
             addedRecipe = true;
         }
@@ -48,8 +46,7 @@ public class EnergizedSmelter {
     public static void removeRecipe(IIngredient itemInput, @Optional IIngredient itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, ItemStackOutput, SmeltingRecipe>(NAME,
-                        Recipe.ENERGIZED_SMELTER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.ENERGIZED_SMELTER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput)));
             removedRecipe = true;
         }
@@ -57,7 +54,6 @@ public class EnergizedSmelter {
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<SmeltingRecipe>(NAME, Recipe.ENERGIZED_SMELTER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.ENERGIZED_SMELTER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Enrichment.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Enrichment.java
@@ -11,9 +11,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -28,7 +26,7 @@ public class Enrichment {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.ENRICHMENT_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.ENRICHMENT_CHAMBER,
                         new EnrichmentRecipe(IngredientHelper.toStack(itemInput),
                               IngredientHelper.toStack(itemOutput))));
         }
@@ -38,15 +36,13 @@ public class Enrichment {
     public static void removeRecipe(IIngredient itemInput, @Optional IIngredient itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, ItemStackOutput, EnrichmentRecipe>(NAME,
-                        Recipe.ENRICHMENT_CHAMBER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.ENRICHMENT_CHAMBER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<EnrichmentRecipe>(NAME, Recipe.ENRICHMENT_CHAMBER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.ENRICHMENT_CHAMBER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Infuser.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Infuser.java
@@ -34,7 +34,7 @@ public class Infuser {
         }
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.METALLURGIC_INFUSER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.METALLURGIC_INFUSER,
                         new MetallurgicInfuserRecipe(new InfusionInput(InfuseRegistry.get(infuseType), infuseAmount,
                               IngredientHelper.toStack(itemInput)),
                               new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
@@ -46,15 +46,13 @@ public class Infuser {
           @Optional String infuseType) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<InfusionInput, ItemStackOutput, MetallurgicInfuserRecipe>(NAME,
-                        Recipe.METALLURGIC_INFUSER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.METALLURGIC_INFUSER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput, infuseType)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<MetallurgicInfuserRecipe>(NAME, Recipe.CHEMICAL_CRYSTALLIZER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.CHEMICAL_CRYSTALLIZER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Purification.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Purification.java
@@ -30,7 +30,7 @@ public class Purification {
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.PURIFICATION_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.PURIFICATION_CHAMBER,
                         new PurificationRecipe(IngredientHelper.toStack(itemInput),
                               IngredientHelper.toStack(itemOutput))));
         }
@@ -40,7 +40,7 @@ public class Purification {
     public static void addRecipe(IItemStack itemInput, IGasStack gasInput, IItemStack itemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, gasInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.PURIFICATION_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.PURIFICATION_CHAMBER,
                         new PurificationRecipe(new AdvancedMachineInput(IngredientHelper.toStack(itemInput),
                               GasHelper.toGas(gasInput).getGas()),
                               new ItemStackOutput(IngredientHelper.toStack(itemOutput)))));
@@ -52,15 +52,13 @@ public class Purification {
           @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<AdvancedMachineInput, ItemStackOutput, PurificationRecipe>(NAME,
-                        Recipe.PURIFICATION_CHAMBER, new IngredientWrapper(itemOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.PURIFICATION_CHAMBER, new IngredientWrapper(itemOutput),
                         new IngredientWrapper(itemInput, gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<PurificationRecipe>(NAME, Recipe.PURIFICATION_CHAMBER));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.PURIFICATION_CHAMBER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Reaction.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Reaction.java
@@ -32,7 +32,7 @@ public class Reaction {
           IItemStack itemOutput, IGasStack gasOutput, double energy, int duration) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, liquidInput, gasInput, itemOutput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER,
                         new PressurizedRecipe(
                               new PressurizedInput(IngredientHelper.toStack(itemInput),
                                     IngredientHelper.toFluid(liquidInput), GasHelper.toGas(gasInput)),
@@ -46,8 +46,8 @@ public class Reaction {
           @Optional IIngredient liquidInput, @Optional IIngredient gasInput) {
         if (IngredientHelper.checkNotNull(NAME, itemOutput, gasOutput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<PressurizedInput, PressurizedOutput, PressurizedRecipe>(NAME,
-                        Recipe.PRESSURIZED_REACTION_CHAMBER, new IngredientWrapper(itemOutput, gasOutput),
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER,
+                        new IngredientWrapper(itemOutput, gasOutput),
                         new IngredientWrapper(itemInput, liquidInput, gasInput)));
         }
     }
@@ -55,6 +55,6 @@ public class Reaction {
     @ZenMethod
     public static void removeAllRecipes() {
         CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<PressurizedRecipe>(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER));
+              .add(new RemoveAllMekanismRecipe<>(NAME, Recipe.PRESSURIZED_REACTION_CHAMBER));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Sawmill.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Sawmill.java
@@ -29,7 +29,7 @@ public class Sawmill {
           @Optional double optionalChance) {
         if (IngredientHelper.checkNotNull(NAME, itemInput, itemOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.PRECISION_SAWMILL,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.PRECISION_SAWMILL,
                         new SawmillRecipe(new ItemStackInput(IngredientHelper.toStack(itemInput)),
                               optionalItemOutput == null ? new ChanceOutput(IngredientHelper.toStack(itemOutput))
                                     : new ChanceOutput(IngredientHelper.toStack(itemOutput),
@@ -42,15 +42,13 @@ public class Sawmill {
           @Optional IIngredient optionalItemOutput) {
         if (IngredientHelper.checkNotNull(NAME, itemInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<ItemStackInput, ChanceOutput, SawmillRecipe>(NAME,
-                        Recipe.PRECISION_SAWMILL, new IngredientWrapper(itemOutput, optionalItemOutput),
-                        new IngredientWrapper(itemInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.PRECISION_SAWMILL,
+                        new IngredientWrapper(itemOutput, optionalItemOutput), new IngredientWrapper(itemInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<SawmillRecipe>(NAME, Recipe.PRECISION_SAWMILL));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.PRECISION_SAWMILL));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Separator.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Separator.java
@@ -13,9 +13,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.FluidInput;
 import mekanism.common.recipe.machines.SeparatorRecipe;
-import mekanism.common.recipe.outputs.ChemicalPairOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -31,7 +29,7 @@ public class Separator {
           IGasStack rightGasOutput) {
         if (IngredientHelper.checkNotNull(NAME, liquidInput, leftGasOutput, rightGasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.ELECTROLYTIC_SEPARATOR,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.ELECTROLYTIC_SEPARATOR,
                         new SeparatorRecipe(IngredientHelper.toFluid(liquidInput), energy,
                               GasHelper.toGas(leftGasOutput), GasHelper.toGas(rightGasOutput))));
         }
@@ -42,15 +40,13 @@ public class Separator {
           @Optional IIngredient rightGasOutput) {
         if (IngredientHelper.checkNotNull(NAME, liquidInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<FluidInput, ChemicalPairOutput, SeparatorRecipe>(NAME,
-                        Recipe.ELECTROLYTIC_SEPARATOR, new IngredientWrapper(leftGasOutput, rightGasOutput),
-                        new IngredientWrapper(liquidInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.ELECTROLYTIC_SEPARATOR,
+                        new IngredientWrapper(leftGasOutput, rightGasOutput), new IngredientWrapper(liquidInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<SeparatorRecipe>(NAME, Recipe.ELECTROLYTIC_SEPARATOR));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.ELECTROLYTIC_SEPARATOR));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/SolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/SolarNeutronActivator.java
@@ -12,9 +12,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.SolarNeutronRecipe;
-import mekanism.common.recipe.outputs.GasOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -29,7 +27,7 @@ public class SolarNeutronActivator {
     public static void addRecipe(IGasStack gasInput, IGasStack gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, gasInput, gasOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.SOLAR_NEUTRON_ACTIVATOR,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.SOLAR_NEUTRON_ACTIVATOR,
                         new SolarNeutronRecipe(GasHelper.toGas(gasInput), GasHelper.toGas(gasOutput))));
         }
     }
@@ -38,15 +36,13 @@ public class SolarNeutronActivator {
     public static void removeRecipe(IIngredient gasInput, @Optional IIngredient gasOutput) {
         if (IngredientHelper.checkNotNull(NAME, gasInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<GasInput, GasOutput, SolarNeutronRecipe>(NAME,
-                        Recipe.SOLAR_NEUTRON_ACTIVATOR, new IngredientWrapper(gasOutput),
-                        new IngredientWrapper(gasInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.SOLAR_NEUTRON_ACTIVATOR,
+                        new IngredientWrapper(gasOutput), new IngredientWrapper(gasInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
-        CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<SolarNeutronRecipe>(NAME, Recipe.SOLAR_NEUTRON_ACTIVATOR));
+        CrafttweakerIntegration.LATE_REMOVALS.add(new RemoveAllMekanismRecipe<>(NAME, Recipe.SOLAR_NEUTRON_ACTIVATOR));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/ThermalEvaporation.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/ThermalEvaporation.java
@@ -11,9 +11,7 @@ import mekanism.common.integration.crafttweaker.util.IngredientWrapper;
 import mekanism.common.integration.crafttweaker.util.RemoveAllMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.FluidInput;
 import mekanism.common.recipe.machines.ThermalEvaporationRecipe;
-import mekanism.common.recipe.outputs.FluidOutput;
 import stanhebben.zenscript.annotations.Optional;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
@@ -28,7 +26,7 @@ public class ThermalEvaporation {
     public static void addRecipe(ILiquidStack liquidInput, ILiquidStack liquidOutput) {
         if (IngredientHelper.checkNotNull(NAME, liquidInput, liquidOutput)) {
             CrafttweakerIntegration.LATE_ADDITIONS
-                  .add(new AddMekanismRecipe(NAME, Recipe.THERMAL_EVAPORATION_PLANT,
+                  .add(new AddMekanismRecipe<>(NAME, Recipe.THERMAL_EVAPORATION_PLANT,
                         new ThermalEvaporationRecipe(IngredientHelper.toFluid(liquidInput),
                               IngredientHelper.toFluid(liquidOutput))));
         }
@@ -38,15 +36,14 @@ public class ThermalEvaporation {
     public static void removeRecipe(IIngredient liquidInput, @Optional IIngredient liquidOutput) {
         if (IngredientHelper.checkNotNull(NAME, liquidInput)) {
             CrafttweakerIntegration.LATE_REMOVALS
-                  .add(new RemoveMekanismRecipe<FluidInput, FluidOutput, ThermalEvaporationRecipe>(NAME,
-                        Recipe.THERMAL_EVAPORATION_PLANT, new IngredientWrapper(liquidOutput),
-                        new IngredientWrapper(liquidInput)));
+                  .add(new RemoveMekanismRecipe<>(NAME, Recipe.THERMAL_EVAPORATION_PLANT,
+                        new IngredientWrapper(liquidOutput), new IngredientWrapper(liquidInput)));
         }
     }
 
     @ZenMethod
     public static void removeAllRecipes() {
         CrafttweakerIntegration.LATE_REMOVALS
-              .add(new RemoveAllMekanismRecipe<ThermalEvaporationRecipe>(NAME, Recipe.THERMAL_EVAPORATION_PLANT));
+              .add(new RemoveAllMekanismRecipe<>(NAME, Recipe.THERMAL_EVAPORATION_PLANT));
     }
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/AddMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/AddMekanismRecipe.java
@@ -3,10 +3,12 @@ package mekanism.common.integration.crafttweaker.util;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
+import mekanism.common.recipe.outputs.MachineOutput;
 
-public class AddMekanismRecipe extends RecipeMapModification<MachineInput, MachineRecipe> {
+public class AddMekanismRecipe<INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>> extends
+      RecipeMapModification<INPUT, RECIPE> {
 
-    public AddMekanismRecipe(String name, Recipe recipeType, MachineRecipe recipe) {
+    public AddMekanismRecipe(String name, Recipe<INPUT, OUTPUT, RECIPE> recipeType, RECIPE recipe) {
         super(name, true, recipeType);
         recipes.put(recipe.getInput(), recipe);
     }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
@@ -13,14 +13,15 @@ import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
 
-public abstract class RecipeMapModification<K extends MachineInput, V extends MachineRecipe> implements IAction {
+public abstract class RecipeMapModification<INPUT extends MachineInput<INPUT>, RECIPE extends MachineRecipe<INPUT, ?, RECIPE>> implements
+      IAction {
 
-    protected final HashMap<K, V> recipes;
-    protected final Map<K, V> map;
+    protected final HashMap<INPUT, RECIPE> recipes;
+    protected final Map<INPUT, RECIPE> map;
     protected final String name;
     protected boolean add;
 
-    protected RecipeMapModification(String name, boolean add, Recipe recipeType) {
+    protected RecipeMapModification(String name, boolean add, Recipe<INPUT, ?, RECIPE> recipeType) {
         this.name = name;
         this.map = recipeType.get();
         this.add = add;
@@ -31,16 +32,16 @@ public abstract class RecipeMapModification<K extends MachineInput, V extends Ma
     public void apply() {
         if (!recipes.isEmpty()) {
             if (add) {
-                for (Entry<K, V> entry : recipes.entrySet()) {
-                    K key = entry.getKey();
-                    V value = entry.getValue();
+                for (Entry<INPUT, RECIPE> entry : recipes.entrySet()) {
+                    INPUT key = entry.getKey();
+                    RECIPE value = entry.getValue();
                     if (map.put(key, value) != null) {
                         CraftTweakerAPI.logInfo(String.format("Overwritten %s Recipe for %s", name,
                               RecipeInfoHelper.getRecipeInfo(new AbstractMap.SimpleEntry<>(entry.getKey(), value))));
                     }
                 }
             } else {
-                for (K key : recipes.keySet()) {
+                for (INPUT key : recipes.keySet()) {
                     if (map.remove(key) == null) {
                         CraftTweakerAPI.logError(String.format("Error removing %s Recipe : null object", name));
                     }
@@ -61,5 +62,4 @@ public abstract class RecipeMapModification<K extends MachineInput, V extends Ma
     public String describe() {
         return String.format("Removing %d %s Recipe(s) for %s", recipes.size(), name, getRecipeInfo());
     }
-
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveAllMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveAllMekanismRecipe.java
@@ -3,10 +3,12 @@ package mekanism.common.integration.crafttweaker.util;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
+import mekanism.common.recipe.outputs.MachineOutput;
 
-public class RemoveAllMekanismRecipe<RECIPE extends MachineRecipe> extends RecipeMapModification<MachineInput, RECIPE> {
+public class RemoveAllMekanismRecipe<INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>> extends
+      RecipeMapModification<INPUT, RECIPE> {
 
-    public RemoveAllMekanismRecipe(String name, Recipe recipeType) {
+    public RemoveAllMekanismRecipe(String name, Recipe<INPUT, OUTPUT, RECIPE> recipeType) {
         super(name, false, recipeType);
     }
 

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveMekanismRecipe.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RemoveMekanismRecipe.java
@@ -13,7 +13,8 @@ public class RemoveMekanismRecipe<INPUT extends MachineInput<INPUT>, OUTPUT exte
     private final IngredientWrapper input;
     private final IngredientWrapper output;
 
-    public RemoveMekanismRecipe(String name, Recipe recipeType, IngredientWrapper output, IngredientWrapper input) {
+    public RemoveMekanismRecipe(String name, Recipe<INPUT, OUTPUT, RECIPE> recipeType, IngredientWrapper output,
+          IngredientWrapper input) {
         super(name, false, recipeType);
         this.input = input;
         this.output = output;

--- a/src/main/java/mekanism/common/inventory/container/ContainerMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerMetallurgicInfuser.java
@@ -82,15 +82,10 @@ public class ContainerMetallurgicInfuser extends ContainerMekanism<TileEntityMet
             return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(tileEntity.infuseStored, itemStack))
                   != null;
         } else {
-            for (Object obj : Recipe.METALLURGIC_INFUSER.get().keySet()) {
-                InfusionInput input = (InfusionInput) obj;
-                if (input.inputStack.isItemEqual(itemStack)) {
-                    return true;
-                }
-            }
+            return Recipe.METALLURGIC_INFUSER.get().keySet().stream()
+                  .anyMatch(input -> input.inputStack.isItemEqual(itemStack));
         }
 
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -593,76 +593,79 @@ public final class RecipeHandler {
         private static final List<Recipe> values = new ArrayList<>();
 
         public static final Recipe<ItemStackInput, ItemStackOutput, SmeltingRecipe> ENERGIZED_SMELTER = new Recipe<>(
-              MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class,
+              MachineType.ENERGIZED_SMELTER.blockName, "ENERGIZED_SMELTER", ItemStackInput.class, ItemStackOutput.class,
               SmeltingRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, EnrichmentRecipe> ENRICHMENT_CHAMBER = new Recipe<>(
-              MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class,
-              EnrichmentRecipe.class);
+              MachineType.ENRICHMENT_CHAMBER.blockName, "ENRICHMENT_CHAMBER", ItemStackInput.class,
+              ItemStackOutput.class, EnrichmentRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, OsmiumCompressorRecipe> OSMIUM_COMPRESSOR = new Recipe<>(
-              MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class,
-              OsmiumCompressorRecipe.class);
+              MachineType.OSMIUM_COMPRESSOR.blockName, "OSMIUM_COMPRESSOR", AdvancedMachineInput.class,
+              ItemStackOutput.class, OsmiumCompressorRecipe.class);
 
         public static final Recipe<DoubleMachineInput, ItemStackOutput, CombinerRecipe> COMBINER = new Recipe<>(
-              MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
+              MachineType.COMBINER.blockName, "COMBINER", DoubleMachineInput.class, ItemStackOutput.class,
+              CombinerRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, CrusherRecipe> CRUSHER = new Recipe<>(
-              MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
+              MachineType.CRUSHER.blockName, "CRUSHER", ItemStackInput.class, ItemStackOutput.class,
+              CrusherRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, PurificationRecipe> PURIFICATION_CHAMBER = new Recipe<>(
-              MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class,
+              MachineType.PURIFICATION_CHAMBER.blockName, "PURIFICATION_CHAMBER", AdvancedMachineInput.class,
               ItemStackOutput.class, PurificationRecipe.class);
 
         public static final Recipe<InfusionInput, ItemStackOutput, MetallurgicInfuserRecipe> METALLURGIC_INFUSER = new Recipe<>(
-              MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class,
-              MetallurgicInfuserRecipe.class);
+              MachineType.METALLURGIC_INFUSER.blockName, "METALLURGIC_INFUSER", InfusionInput.class,
+              ItemStackOutput.class, MetallurgicInfuserRecipe.class);
 
         public static final Recipe<ChemicalPairInput, GasOutput, ChemicalInfuserRecipe> CHEMICAL_INFUSER = new Recipe<>(
-              MachineType.CHEMICAL_INFUSER.blockName, ChemicalPairInput.class, GasOutput.class,
+              MachineType.CHEMICAL_INFUSER.blockName, "CHEMICAL_INFUSER", ChemicalPairInput.class, GasOutput.class,
               ChemicalInfuserRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, OxidationRecipe> CHEMICAL_OXIDIZER = new Recipe<>(
-              MachineType.CHEMICAL_OXIDIZER.blockName, ItemStackInput.class, GasOutput.class,
+              MachineType.CHEMICAL_OXIDIZER.blockName, "CHEMICAL_OXIDIZER", ItemStackInput.class, GasOutput.class,
               OxidationRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, InjectionRecipe> CHEMICAL_INJECTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, AdvancedMachineInput.class,
-              ItemStackOutput.class, InjectionRecipe.class);
+              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, "CHEMICAL_INJECTION_CHAMBER",
+              AdvancedMachineInput.class, ItemStackOutput.class, InjectionRecipe.class);
 
         public static final Recipe<FluidInput, ChemicalPairOutput, SeparatorRecipe> ELECTROLYTIC_SEPARATOR = new Recipe<>(
-              MachineType.ELECTROLYTIC_SEPARATOR.blockName, FluidInput.class, ChemicalPairOutput.class,
-              SeparatorRecipe.class);
+              MachineType.ELECTROLYTIC_SEPARATOR.blockName, "ELECTROLYTIC_SEPARATOR", FluidInput.class,
+              ChemicalPairOutput.class, SeparatorRecipe.class);
 
         public static final Recipe<ItemStackInput, ChanceOutput, SawmillRecipe> PRECISION_SAWMILL = new Recipe<>(
-              MachineType.PRECISION_SAWMILL.blockName, ItemStackInput.class, ChanceOutput.class,
+              MachineType.PRECISION_SAWMILL.blockName, "PRECISION_SAWMILL", ItemStackInput.class, ChanceOutput.class,
               SawmillRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, DissolutionRecipe> CHEMICAL_DISSOLUTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, ItemStackInput.class,
+              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, "CHEMICAL_DISSOLUTION_CHAMBER", ItemStackInput.class,
               GasOutput.class, DissolutionRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, WasherRecipe> CHEMICAL_WASHER = new Recipe<>(
-              MachineType.CHEMICAL_WASHER.blockName, GasInput.class, GasOutput.class, WasherRecipe.class);
+              MachineType.CHEMICAL_WASHER.blockName, "CHEMICAL_WASHER", GasInput.class, GasOutput.class,
+              WasherRecipe.class);
 
         public static final Recipe<GasInput, ItemStackOutput, CrystallizerRecipe> CHEMICAL_CRYSTALLIZER = new Recipe<>(
-              MachineType.CHEMICAL_CRYSTALLIZER.blockName, GasInput.class, ItemStackOutput.class,
-              CrystallizerRecipe.class);
+              MachineType.CHEMICAL_CRYSTALLIZER.blockName, "CHEMICAL_CRYSTALLIZER", GasInput.class,
+              ItemStackOutput.class, CrystallizerRecipe.class);
 
         public static final Recipe<PressurizedInput, PressurizedOutput, PressurizedRecipe> PRESSURIZED_REACTION_CHAMBER = new Recipe<>(
-              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, PressurizedInput.class,
-              PressurizedOutput.class, PressurizedRecipe.class);
+              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, "PRESSURIZED_REACTION_CHAMBER",
+              PressurizedInput.class, PressurizedOutput.class, PressurizedRecipe.class);
 
         public static final Recipe<IntegerInput, GasOutput, AmbientGasRecipe> AMBIENT_ACCUMULATOR = new Recipe<>(
-              MachineType.AMBIENT_ACCUMULATOR.blockName, IntegerInput.class, GasOutput.class,
+              MachineType.AMBIENT_ACCUMULATOR.blockName, "AMBIENT_ACCUMULATOR", IntegerInput.class, GasOutput.class,
               AmbientGasRecipe.class);
 
         public static final Recipe<FluidInput, FluidOutput, ThermalEvaporationRecipe> THERMAL_EVAPORATION_PLANT = new Recipe<>(
-              "ThermalEvaporationPlant", FluidInput.class, FluidOutput.class,
+              "ThermalEvaporationPlant", "THERMAL_EVAPORATION_PLANT", FluidInput.class, FluidOutput.class,
               ThermalEvaporationRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, SolarNeutronRecipe> SOLAR_NEUTRON_ACTIVATOR = new Recipe<>(
-              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, GasInput.class, GasOutput.class,
+              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, "SOLAR_NEUTRON_ACTIVATOR", GasInput.class, GasOutput.class,
               SolarNeutronRecipe.class);
 
         //TODO: Replace this with Recipe being Iterable
@@ -672,6 +675,7 @@ public final class RecipeHandler {
 
         private final Map<INPUT, RECIPE> recipes = new HashMap<>();
         private final String recipeName;
+        private final String oldRecipeName;
         private final String jeiCategory;
 
         private Class<? extends MachineInput> inputClass;
@@ -679,8 +683,9 @@ public final class RecipeHandler {
         private Class<? extends MachineRecipe> recipeClass;
 
 
-        private Recipe(String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
+        private Recipe(String name, String oldName, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
             recipeName = name;
+            oldRecipeName = oldName;
             jeiCategory = "mekanism." + recipeName.toLowerCase(Locale.ROOT);
 
             inputClass = input;
@@ -700,6 +705,10 @@ public final class RecipeHandler {
 
         public String getRecipeName() {
             return recipeName;
+        }
+
+        public String getOldRecipeName() {
+            return oldRecipeName;
         }
 
         public String getJEICategory() {

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
+import java.util.Map.Entry;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.infuse.InfuseType;
@@ -296,7 +296,7 @@ public final class RecipeHandler {
      */
     public static MetallurgicInfuserRecipe getMetallurgicInfuserRecipe(InfusionInput input) {
         if (input.isValid()) {
-            HashMap<InfusionInput, MetallurgicInfuserRecipe> recipes = Recipe.METALLURGIC_INFUSER.get();
+            Map<InfusionInput, MetallurgicInfuserRecipe> recipes = Recipe.METALLURGIC_INFUSER.get();
 
             MetallurgicInfuserRecipe recipe = recipes.get(input);
 
@@ -318,7 +318,7 @@ public final class RecipeHandler {
      */
     public static ChemicalInfuserRecipe getChemicalInfuserRecipe(ChemicalPairInput input) {
         if (input.isValid()) {
-            HashMap<ChemicalPairInput, ChemicalInfuserRecipe> recipes = Recipe.CHEMICAL_INFUSER.get();
+            Map<ChemicalPairInput, ChemicalInfuserRecipe> recipes = Recipe.CHEMICAL_INFUSER.get();
 
             ChemicalInfuserRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -335,7 +335,7 @@ public final class RecipeHandler {
      */
     public static CrystallizerRecipe getChemicalCrystallizerRecipe(GasInput input) {
         if (input.isValid()) {
-            HashMap<GasInput, CrystallizerRecipe> recipes = Recipe.CHEMICAL_CRYSTALLIZER.get();
+            Map<GasInput, CrystallizerRecipe> recipes = Recipe.CHEMICAL_CRYSTALLIZER.get();
 
             CrystallizerRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -352,7 +352,7 @@ public final class RecipeHandler {
      */
     public static WasherRecipe getChemicalWasherRecipe(GasInput input) {
         if (input.isValid()) {
-            HashMap<GasInput, WasherRecipe> recipes = Recipe.CHEMICAL_WASHER.get();
+            Map<GasInput, WasherRecipe> recipes = Recipe.CHEMICAL_WASHER.get();
 
             WasherRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -369,7 +369,7 @@ public final class RecipeHandler {
      */
     public static DissolutionRecipe getDissolutionRecipe(ItemStackInput input) {
         if (input.isValid()) {
-            HashMap<ItemStackInput, DissolutionRecipe> recipes = Recipe.CHEMICAL_DISSOLUTION_CHAMBER.get();
+            Map<ItemStackInput, DissolutionRecipe> recipes = Recipe.CHEMICAL_DISSOLUTION_CHAMBER.get();
 
             DissolutionRecipe recipe = getRecipeTryWildcard(input, recipes);
             return recipe == null ? null : recipe.copy();
@@ -386,7 +386,7 @@ public final class RecipeHandler {
      */
     public static OxidationRecipe getOxidizerRecipe(ItemStackInput input) {
         if (input.isValid()) {
-            HashMap<ItemStackInput, OxidationRecipe> recipes = Recipe.CHEMICAL_OXIDIZER.get();
+            Map<ItemStackInput, OxidationRecipe> recipes = Recipe.CHEMICAL_OXIDIZER.get();
 
             OxidationRecipe recipe = getRecipeTryWildcard(input, recipes);
             return recipe == null ? null : recipe.copy();
@@ -482,7 +482,7 @@ public final class RecipeHandler {
      */
     public static SeparatorRecipe getElectrolyticSeparatorRecipe(FluidInput input) {
         if (input.isValid()) {
-            HashMap<FluidInput, SeparatorRecipe> recipes = Recipe.ELECTROLYTIC_SEPARATOR.get();
+            Map<FluidInput, SeparatorRecipe> recipes = Recipe.ELECTROLYTIC_SEPARATOR.get();
 
             SeparatorRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -493,7 +493,7 @@ public final class RecipeHandler {
 
     public static ThermalEvaporationRecipe getThermalEvaporationRecipe(FluidInput input) {
         if (input.isValid()) {
-            HashMap<FluidInput, ThermalEvaporationRecipe> recipes = Recipe.THERMAL_EVAPORATION_PLANT.get();
+            Map<FluidInput, ThermalEvaporationRecipe> recipes = Recipe.THERMAL_EVAPORATION_PLANT.get();
 
             ThermalEvaporationRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -504,7 +504,7 @@ public final class RecipeHandler {
 
     public static SolarNeutronRecipe getSolarNeutronRecipe(GasInput input) {
         if (input.isValid()) {
-            HashMap<GasInput, SolarNeutronRecipe> recipes = Recipe.SOLAR_NEUTRON_ACTIVATOR.get();
+            Map<GasInput, SolarNeutronRecipe> recipes = Recipe.SOLAR_NEUTRON_ACTIVATOR.get();
 
             SolarNeutronRecipe recipe = recipes.get(input);
             return recipe == null ? null : recipe.copy();
@@ -515,7 +515,7 @@ public final class RecipeHandler {
 
     public static PressurizedRecipe getPRCRecipe(PressurizedInput input) {
         if (input.isValid()) {
-            HashMap<PressurizedInput, PressurizedRecipe> recipes = Recipe.PRESSURIZED_REACTION_CHAMBER.get();
+            Map<PressurizedInput, PressurizedRecipe> recipes = Recipe.PRESSURIZED_REACTION_CHAMBER.get();
 
             PressurizedRecipe recipe = recipes.get(input);
 
@@ -530,7 +530,7 @@ public final class RecipeHandler {
     }
 
     public static AmbientGasRecipe getDimensionGas(IntegerInput input) {
-        HashMap<IntegerInput, AmbientGasRecipe> recipes = Recipe.AMBIENT_ACCUMULATOR.get();
+        Map<IntegerInput, AmbientGasRecipe> recipes = Recipe.AMBIENT_ACCUMULATOR.get();
         AmbientGasRecipe recipe = recipes.get(input);
 
         return recipe == null ? null : recipe.copy();
@@ -562,7 +562,7 @@ public final class RecipeHandler {
 
     public static boolean isInPressurizedRecipe(ItemStack stack) {
         if (!stack.isEmpty()) {
-            for (PressurizedInput key : (Set<PressurizedInput>) Recipe.PRESSURIZED_REACTION_CHAMBER.get().keySet()) {
+            for (PressurizedInput key : Recipe.PRESSURIZED_REACTION_CHAMBER.get().keySet()) {
                 if (key.containsType(stack)) {
                     return true;
                 }
@@ -588,66 +588,113 @@ public final class RecipeHandler {
         return recipe;
     }
 
-    public enum Recipe {
-        ENERGIZED_SMELTER(MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class,
-              SmeltingRecipe.class),
-        ENRICHMENT_CHAMBER(MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class,
-              EnrichmentRecipe.class),
-        OSMIUM_COMPRESSOR(MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class,
-              OsmiumCompressorRecipe.class),
-        COMBINER(MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class),
-        CRUSHER(MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class),
-        PURIFICATION_CHAMBER(MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class,
-              ItemStackOutput.class, PurificationRecipe.class),
-        METALLURGIC_INFUSER(MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class,
-              MetallurgicInfuserRecipe.class),
-        CHEMICAL_INFUSER(MachineType.CHEMICAL_INFUSER.blockName, ChemicalPairInput.class, GasOutput.class,
-              ChemicalInfuserRecipe.class),
-        CHEMICAL_OXIDIZER(MachineType.CHEMICAL_OXIDIZER.blockName, ItemStackInput.class, GasOutput.class,
-              OxidationRecipe.class),
-        CHEMICAL_INJECTION_CHAMBER(MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, AdvancedMachineInput.class,
-              ItemStackOutput.class, InjectionRecipe.class),
-        ELECTROLYTIC_SEPARATOR(MachineType.ELECTROLYTIC_SEPARATOR.blockName, FluidInput.class, ChemicalPairOutput.class,
-              SeparatorRecipe.class),
-        PRECISION_SAWMILL(MachineType.PRECISION_SAWMILL.blockName, ItemStackInput.class, ChanceOutput.class,
-              SawmillRecipe.class),
-        CHEMICAL_DISSOLUTION_CHAMBER(MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, ItemStackInput.class,
-              GasOutput.class, DissolutionRecipe.class),
-        CHEMICAL_WASHER(MachineType.CHEMICAL_WASHER.blockName, GasInput.class, GasOutput.class, WasherRecipe.class),
-        CHEMICAL_CRYSTALLIZER(MachineType.CHEMICAL_CRYSTALLIZER.blockName, GasInput.class, ItemStackOutput.class,
-              CrystallizerRecipe.class),
-        PRESSURIZED_REACTION_CHAMBER(MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, PressurizedInput.class,
-              PressurizedOutput.class, PressurizedRecipe.class),
-        AMBIENT_ACCUMULATOR(MachineType.AMBIENT_ACCUMULATOR.blockName, IntegerInput.class, GasOutput.class,
-              AmbientGasRecipe.class),
-        THERMAL_EVAPORATION_PLANT("ThermalEvaporationPlant", FluidInput.class, FluidOutput.class,
-              ThermalEvaporationRecipe.class),
-        SOLAR_NEUTRON_ACTIVATOR(MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, GasInput.class, GasOutput.class,
+    public static class Recipe<INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>> {
+
+        private static final List<Recipe> values = new ArrayList<>();
+
+        public static final Recipe<ItemStackInput, ItemStackOutput, SmeltingRecipe> ENERGIZED_SMELTER = new Recipe<>(
+              MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class,
+              SmeltingRecipe.class);
+
+        public static final Recipe<ItemStackInput, ItemStackOutput, EnrichmentRecipe> ENRICHMENT_CHAMBER = new Recipe<>(
+              MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class,
+              EnrichmentRecipe.class);
+
+        public static final Recipe<AdvancedMachineInput, ItemStackOutput, OsmiumCompressorRecipe> OSMIUM_COMPRESSOR = new Recipe<>(
+              MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class,
+              OsmiumCompressorRecipe.class);
+
+        public static final Recipe<DoubleMachineInput, ItemStackOutput, CombinerRecipe> COMBINER = new Recipe<>(
+              MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
+
+        public static final Recipe<ItemStackInput, ItemStackOutput, CrusherRecipe> CRUSHER = new Recipe<>(
+              MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
+
+        public static final Recipe<AdvancedMachineInput, ItemStackOutput, PurificationRecipe> PURIFICATION_CHAMBER = new Recipe<>(
+              MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class,
+              ItemStackOutput.class, PurificationRecipe.class);
+
+        public static final Recipe<InfusionInput, ItemStackOutput, MetallurgicInfuserRecipe> METALLURGIC_INFUSER = new Recipe<>(
+              MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class,
+              MetallurgicInfuserRecipe.class);
+
+        public static final Recipe<ChemicalPairInput, GasOutput, ChemicalInfuserRecipe> CHEMICAL_INFUSER = new Recipe<>(
+              MachineType.CHEMICAL_INFUSER.blockName, ChemicalPairInput.class, GasOutput.class,
+              ChemicalInfuserRecipe.class);
+
+        public static final Recipe<ItemStackInput, GasOutput, OxidationRecipe> CHEMICAL_OXIDIZER = new Recipe<>(
+              MachineType.CHEMICAL_OXIDIZER.blockName, ItemStackInput.class, GasOutput.class,
+              OxidationRecipe.class);
+
+        public static final Recipe<AdvancedMachineInput, ItemStackOutput, InjectionRecipe> CHEMICAL_INJECTION_CHAMBER = new Recipe<>(
+              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, AdvancedMachineInput.class,
+              ItemStackOutput.class, InjectionRecipe.class);
+
+        public static final Recipe<FluidInput, ChemicalPairOutput, SeparatorRecipe> ELECTROLYTIC_SEPARATOR = new Recipe<>(
+              MachineType.ELECTROLYTIC_SEPARATOR.blockName, FluidInput.class, ChemicalPairOutput.class,
+              SeparatorRecipe.class);
+
+        public static final Recipe<ItemStackInput, ChanceOutput, SawmillRecipe> PRECISION_SAWMILL = new Recipe<>(
+              MachineType.PRECISION_SAWMILL.blockName, ItemStackInput.class, ChanceOutput.class,
+              SawmillRecipe.class);
+
+        public static final Recipe<ItemStackInput, GasOutput, DissolutionRecipe> CHEMICAL_DISSOLUTION_CHAMBER = new Recipe<>(
+              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, ItemStackInput.class,
+              GasOutput.class, DissolutionRecipe.class);
+
+        public static final Recipe<GasInput, GasOutput, WasherRecipe> CHEMICAL_WASHER = new Recipe<>(
+              MachineType.CHEMICAL_WASHER.blockName, GasInput.class, GasOutput.class, WasherRecipe.class);
+
+        public static final Recipe<GasInput, ItemStackOutput, CrystallizerRecipe> CHEMICAL_CRYSTALLIZER = new Recipe<>(
+              MachineType.CHEMICAL_CRYSTALLIZER.blockName, GasInput.class, ItemStackOutput.class,
+              CrystallizerRecipe.class);
+
+        public static final Recipe<PressurizedInput, PressurizedOutput, PressurizedRecipe> PRESSURIZED_REACTION_CHAMBER = new Recipe<>(
+              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, PressurizedInput.class,
+              PressurizedOutput.class, PressurizedRecipe.class);
+
+        public static final Recipe<IntegerInput, GasOutput, AmbientGasRecipe> AMBIENT_ACCUMULATOR = new Recipe<>(
+              MachineType.AMBIENT_ACCUMULATOR.blockName, IntegerInput.class, GasOutput.class,
+              AmbientGasRecipe.class);
+
+        public static final Recipe<FluidInput, FluidOutput, ThermalEvaporationRecipe> THERMAL_EVAPORATION_PLANT = new Recipe<>(
+              "ThermalEvaporationPlant", FluidInput.class, FluidOutput.class,
+              ThermalEvaporationRecipe.class);
+
+        public static final Recipe<GasInput, GasOutput, SolarNeutronRecipe> SOLAR_NEUTRON_ACTIVATOR = new Recipe<>(
+              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, GasInput.class, GasOutput.class,
               SolarNeutronRecipe.class);
 
-        private HashMap recipes;
-        private String recipeName;
+        //TODO: Replace this with Recipe being Iterable
+        public static List<Recipe> values() {
+            return values;
+        }
+
+        private final Map<INPUT, RECIPE> recipes = new HashMap<>();
+        private final String recipeName;
+        private final String jeiCategory;
 
         private Class<? extends MachineInput> inputClass;
         private Class<? extends MachineOutput> outputClass;
         private Class<? extends MachineRecipe> recipeClass;
 
-        <INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, ?, RECIPE>> Recipe(
-              String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
+
+        private Recipe(String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
             recipeName = name;
+            jeiCategory = "mekanism." + recipeName.toLowerCase(Locale.ROOT);
 
             inputClass = input;
             outputClass = output;
             recipeClass = recipe;
 
-            recipes = new HashMap<INPUT, RECIPE>();
+            values.add(this);
         }
 
-        public <RECIPE extends MachineRecipe<?, ?, RECIPE>> void put(RECIPE recipe) {
+        public void put(RECIPE recipe) {
             recipes.put(recipe.getInput(), recipe);
         }
 
-        public <RECIPE extends MachineRecipe<?, ?, RECIPE>> void remove(RECIPE recipe) {
+        public void remove(RECIPE recipe) {
             recipes.remove(recipe.getInput());
         }
 
@@ -655,11 +702,11 @@ public final class RecipeHandler {
             return recipeName;
         }
 
-        public String getName() {
-            return name().toLowerCase(Locale.ROOT);
+        public String getJEICategory() {
+            return jeiCategory;
         }
 
-        public <INPUT> INPUT createInput(NBTTagCompound nbtTags) {
+        public INPUT createInput(NBTTagCompound nbtTags) {
             try {
                 MachineInput input = inputClass.newInstance();
                 input.load(nbtTags);
@@ -670,7 +717,7 @@ public final class RecipeHandler {
             }
         }
 
-        public <RECIPE, INPUT> RECIPE createRecipe(INPUT input, NBTTagCompound nbtTags) {
+        public RECIPE createRecipe(INPUT input, NBTTagCompound nbtTags) {
             try {
                 MachineOutput output = outputClass.newInstance();
                 output.load(nbtTags);
@@ -691,26 +738,22 @@ public final class RecipeHandler {
 
         public boolean containsRecipe(ItemStack input) {
             //TODO: Support other input types
-            for (Object obj : get().entrySet()) {
-                if (obj instanceof Map.Entry) {
-                    Map.Entry entry = (Map.Entry) obj;
+            for (Entry<INPUT, RECIPE> entry : recipes.entrySet()) {
+                if (entry.getKey() instanceof ItemStackInput) {
+                    ItemStack stack = ((ItemStackInput) entry.getKey()).ingredient;
 
-                    if (entry.getKey() instanceof ItemStackInput) {
-                        ItemStack stack = ((ItemStackInput) entry.getKey()).ingredient;
+                    if (StackUtils.equalsWildcard(stack, input)) {
+                        return true;
+                    }
+                } else if (entry.getKey() instanceof FluidInput) {
+                    if (((FluidInput) entry.getKey()).ingredient.isFluidEqual(input)) {
+                        return true;
+                    }
+                } else if (entry.getKey() instanceof AdvancedMachineInput) {
+                    ItemStack stack = ((AdvancedMachineInput) entry.getKey()).itemStack;
 
-                        if (StackUtils.equalsWildcard(stack, input)) {
-                            return true;
-                        }
-                    } else if (entry.getKey() instanceof FluidInput) {
-                        if (((FluidInput) entry.getKey()).ingredient.isFluidEqual(input)) {
-                            return true;
-                        }
-                    } else if (entry.getKey() instanceof AdvancedMachineInput) {
-                        ItemStack stack = ((AdvancedMachineInput) entry.getKey()).itemStack;
-
-                        if (StackUtils.equalsWildcard(stack, input)) {
-                            return true;
-                        }
+                    if (StackUtils.equalsWildcard(stack, input)) {
+                        return true;
                     }
                 }
             }
@@ -720,14 +763,10 @@ public final class RecipeHandler {
 
         public boolean containsRecipe(Fluid input) {
             //TODO: Support other input types
-            for (Object obj : get().entrySet()) {
-                if (obj instanceof Map.Entry) {
-                    Map.Entry entry = (Map.Entry) obj;
-
-                    if (entry.getKey() instanceof FluidInput) {
-                        if (((FluidInput) entry.getKey()).ingredient.getFluid() == input) {
-                            return true;
-                        }
+            for (Entry<INPUT, RECIPE> entry : recipes.entrySet()) {
+                if (entry.getKey() instanceof FluidInput) {
+                    if (((FluidInput) entry.getKey()).ingredient.getFluid() == input) {
+                        return true;
                     }
                 }
             }
@@ -737,27 +776,36 @@ public final class RecipeHandler {
 
         public boolean containsRecipe(Gas input) {
             //TODO: Support other input types
-            for (Object obj : get().entrySet()) {
-                if (obj instanceof Map.Entry) {
-                    Map.Entry entry = (Map.Entry) obj;
-
-                    Gas toCheck = null;
-                    if (entry.getKey() instanceof GasInput) {
-                        toCheck = ((GasInput) entry.getKey()).ingredient.getGas();
-                    } else if (entry.getKey() instanceof AdvancedMachineInput) {
-                        toCheck = ((AdvancedMachineInput) entry.getKey()).gasType;
-                    }
-                    if (toCheck == input) {
-                        return true;
-                    }
+            for (Entry<INPUT, RECIPE> entry : recipes.entrySet()) {
+                Gas toCheck = null;
+                if (entry.getKey() instanceof GasInput) {
+                    toCheck = ((GasInput) entry.getKey()).ingredient.getGas();
+                } else if (entry.getKey() instanceof AdvancedMachineInput) {
+                    toCheck = ((AdvancedMachineInput) entry.getKey()).gasType;
+                }
+                if (toCheck == input) {
+                    return true;
                 }
             }
 
             return false;
         }
 
-        public HashMap get() {
+        public Map<INPUT, RECIPE> get() {
             return recipes;
         }
+
+        /*@Nullable
+        public RECIPE getRecipe(INPUT input) {
+            if (input.isValid()) {
+                RECIPE recipe;
+                recipe = recipes.get(input);
+                if (recipe == null && input instanceof ItemStackInput) {
+                    recipe = recipes.get(((ItemStackInput) input).wildCopy());
+                }
+                return recipe == null ? null : recipe.copy();
+            }
+            return null;
+        }*/
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
+import mekanism.api.TileNetworkList;
 import mekanism.api.infuse.InfuseObject;
 import mekanism.api.infuse.InfuseRegistry;
 import mekanism.api.transmitters.TransmissionType;
@@ -18,7 +19,6 @@ import mekanism.common.base.IFactory.RecipeType;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITierUpgradeable;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.usage;
@@ -216,13 +216,8 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
             if (infuseStored.type != null) {
                 return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(infuseStored, itemstack)) != null;
             } else {
-                for (Object obj : Recipe.METALLURGIC_INFUSER.get().keySet()) {
-                    InfusionInput input = (InfusionInput) obj;
-
-                    if (input.inputStack.isItemEqual(itemstack)) {
-                        return true;
-                    }
-                }
+                return Recipe.METALLURGIC_INFUSER.get().keySet().stream()
+                      .anyMatch(input -> input.inputStack.isItemEqual(itemstack));
             }
         } else if (slotID == 4) {
             return ChargeUtils.canBeDischarged(itemstack);


### PR DESCRIPTION
This also cleans up a lot of unchecked cast warnings, and removes no longer needed instanceof checks.

Also fixes the recipe list command for chemical infuser not working.