### PR TITLE
Fixes incomplete IItemHandler impl of lots of tile entities

### DIFF
--- a/src/main/java/mekanism/common/base/ItemHandlerWrapper.java
+++ b/src/main/java/mekanism/common/base/ItemHandlerWrapper.java
@@ -1,6 +1,8 @@
 package mekanism.common.base;
 
+import javax.annotation.Nonnull;
 import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
@@ -8,5 +10,11 @@ public class ItemHandlerWrapper extends SidedInvWrapper {
 
     public ItemHandlerWrapper(ISidedInventory inv, EnumFacing side) {
         super(inv, side);
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+        int sl = getSlot(inv, slot, side);
+        return sl != -1 && inv.isItemValidForSlot(sl, stack);
     }
 }

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -136,10 +136,17 @@ public class TransporterManager {
         if (InventoryUtils.isItemHandler(tile, side.getOpposite())) {
             IItemHandler inv = InventoryUtils.getItemHandler(tile, side.getOpposite());
 
-            for (int i = 0; i <= inv.getSlots() - 1; i++) {
+            for (int i = 0; i < inv.getSlots(); i++) {
                 if (stack.pathType != Path.HOME) {
+                    //Validate
+                    if (!inv.isItemValid(i, toInsert)) {
+                        continue;
+                    }
+
+                    //Simulate insert
                     ItemStack rejectStack = inv.insertItem(i, toInsert, true);
 
+                    //If failed to insert, skip
                     if (!TransporterManager.didEmit(toInsert, rejectStack)) {
                         continue;
                     }
@@ -381,9 +388,16 @@ public class TransporterManager {
             if (InventoryUtils.isItemHandler(tileEntity, side.getOpposite())) {
                 IItemHandler inventory = InventoryUtils.getItemHandler(tileEntity, side.getOpposite());
 
-                for (int i = 0; i <= inventory.getSlots() - 1; i++) {
+                for (int i = 0; i < inventory.getSlots(); i++) {
+                    //Validate
+                    if (!inventory.isItemValid(i, toInsert)) {
+                        continue;
+                    }
+
+                    //Simulate insert
                     ItemStack rejectStack = inventory.insertItem(i, toInsert, true);
 
+                    //If didn't insert, skip
                     if (!TransporterManager.didEmit(toInsert, rejectStack)) {
                         continue;
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -280,24 +280,25 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
             TransitRequest ejectMap = getEjectItemMap();
 
-            TileEntity ejectInv;
-            TileEntity ejectTile;
-            if (doEject && delayTicks == 0 && !ejectMap.isEmpty() && (ejectInv = getEjectInv()) != null
-                  && (ejectTile = getEjectTile()) != null) {
-                TransitResponse response;
-                if (CapabilityUtils.hasCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY,
-                      facing.getOpposite())) {
-                    response = TransporterUtils.insert(ejectTile, CapabilityUtils
-                          .getCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY,
-                                facing.getOpposite()), ejectMap, null, true, 0);
-                } else {
-                    response = InventoryUtils.putStackInInventory(ejectInv, ejectMap, facing.getOpposite(), false);
-                }
-                if (!response.isEmpty()) {
-                    response.getInvStack(this, facing.getOpposite()).use();
-                }
+            if (doEject && delayTicks == 0 && !ejectMap.isEmpty()) {
+                TileEntity ejectInv = getEjectInv();
+                TileEntity ejectTile = getEjectTile();
+                if (ejectInv != null && ejectTile != null) {
+                    TransitResponse response;
+                    if (CapabilityUtils.hasCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY,
+                          facing.getOpposite())) {
+                        response = TransporterUtils.insert(ejectTile, CapabilityUtils
+                              .getCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY,
+                                    facing.getOpposite()), ejectMap, null, true, 0);
+                    } else {
+                        response = InventoryUtils.putStackInInventory(ejectInv, ejectMap, facing.getOpposite(), false);
+                    }
+                    if (!response.isEmpty()) {
+                        response.getInvStack(this, facing.getOpposite()).use();
+                    }
 
-                delayTicks = 10;
+                    delayTicks = 10;
+                }
             } else if (delayTicks > 0) {
                 delayTicks--;
             }
@@ -345,7 +346,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                   Block.getBlockFromItem(stack.getItem()).getStateFromMeta(stack.getItemDamage()), 3);
 
             IBlockState s = obj.getBlockState(world);
-            if (s.getBlock() instanceof BlockBush && !((BlockBush) s.getBlock()).canBlockStay(world, obj.getPos(), s)) {
+            if (s.getBlock() instanceof BlockBush && !((BlockBush) s.getBlock())
+                  .canBlockStay(world, obj.getPos(), s)) {
                 s.getBlock().dropBlockAsItem(world, obj.getPos(), s, 1);
                 world.setBlockToAir(obj.getPos());
             }
@@ -457,7 +459,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                     added++;
 
                     continue stacks;
-                } else if (testInv.get(i).isItemEqual(stack) && testInv.get(i).getCount() + stack.getCount() <= stack
+                } else if (testInv.get(i).isItemEqual(stack)
+                      && testInv.get(i).getCount() + stack.getCount() <= stack
                       .getMaxStackSize()) {
                     testInv.get(i).grow(stack.getCount());
                     added++;
@@ -886,7 +889,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
         if (clientActive != active) {
             Mekanism.packetHandler
-                  .sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
+                  .sendToReceivers(
+                        new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
                         new Range4D(Coord4D.get(this)));
 
             clientActive = active;

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -5,9 +5,11 @@ import javax.annotation.Nullable;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.content.tank.DynamicFluidTank;
+import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.PipeUtils;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
@@ -102,5 +104,11 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure) ? new int[]{0, 1}
               : InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        //can be filled/emptied
+        return slot == 0 && FluidContainerUtils.isFluidContainer(stack);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.content.tank.DynamicFluidTank;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.util.EnumFacing;
@@ -94,5 +95,12 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure) ? new int[]{0, 1}
+              : InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -26,10 +26,12 @@ import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
+import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumActionResult;
@@ -484,5 +486,10 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             return new int[]{mode ? 0 : 1};
         }
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return ChargeUtils.canBeCharged(stack);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -481,11 +481,9 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
     @Nonnull
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
-            //Inserting into input make it draw power from the item inserted
-            return new int[]{mode ? 0 : 1};
-        }
-        return InventoryUtils.EMPTY;
+        //Inserting into input make it draw power from the item inserted
+        return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure) ? new int[]{
+              mode ? 0 : 1} : InventoryUtils.EMPTY;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -13,10 +13,10 @@ import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
 import mekanism.common.base.IEnergyWrapper;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.capabilities.CapabilityWrapperManager;
 import mekanism.common.config.MekanismConfig.general;
@@ -26,6 +26,7 @@ import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -473,5 +474,15 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
         }
 
         return super.getCapability(capability, facing);
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
+            //Inserting into input make it draw power from the item inserted
+            return new int[]{mode ? 0 : 1};
+        }
+        return InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -345,4 +345,9 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return new int[]{0};
     }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return ChargeUtils.canBeCharged(stack);
+    }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -5,9 +5,9 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IRedstoneControl;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.general;
@@ -338,5 +338,11 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     @Override
     public TileComponentSecurity getSecurity() {
         return securityComponent;
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return new int[]{0};
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -12,6 +12,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasItem;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -360,11 +361,25 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     @Nonnull
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        if (side == MekanismUtils.getRight(facing)) {
-            return new int[]{2, 3};
-        } else if (side == MekanismUtils.getLeft(facing)) {
+        if (side == MekanismUtils.getLeft(facing)) {
+            //Gas
             return new int[]{0, 1};
+        } else if (side == MekanismUtils.getRight(facing)) {
+            //Fluid
+            return new int[]{2, 3};
         }
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        if (slot == 0) {
+            //Gas
+            return stack.getItem() instanceof IGasItem;
+        } else if (slot == 2) {
+            //Fluid
+            return FluidContainerUtils.isFluidContainer(stack);
+        }
+        return false;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
@@ -19,7 +20,6 @@ import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.usage;
@@ -27,6 +27,7 @@ import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityMachine;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.FluidContainerUtils;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
@@ -354,5 +355,16 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     @Override
     public Object[] getTanks() {
         return new Object[]{gasTank, fluidTank};
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        if (side == MekanismUtils.getRight(facing)) {
+            return new int[]{2, 3};
+        } else if (side == MekanismUtils.getLeft(facing)) {
+            return new int[]{0, 1};
+        }
+        return InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -228,4 +228,9 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return new int[]{0};
     }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return ChargeUtils.canBeCharged(stack);
+    }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -222,4 +222,10 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     public AxisAlignedBB getRenderBoundingBox() {
         return INFINITE_EXTENT_AABB;
     }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return new int[]{0};
+    }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
@@ -20,7 +21,6 @@ import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.base.IUpgradeTile;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.recipe.RecipeHandler;
@@ -354,5 +354,11 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
             return .16 * (1 + (world.getTotalWorldTime() % 6));
         }
         return 0;
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return side == facing ? new int[]{1} : new int[]{0};
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -11,6 +11,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
+import mekanism.api.gas.IGasItem;
 import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -360,5 +361,10 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return side == facing ? new int[]{1} : new int[]{0};
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return stack.getItem() instanceof IGasItem;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -7,10 +7,10 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IEvaporationSolar;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
 import mekanism.common.base.ITankManager;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.general;
 import mekanism.common.content.tank.TankUpdateProtocol;
@@ -22,6 +22,7 @@ import mekanism.common.recipe.machines.ThermalEvaporationRecipe;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.FluidContainerUtils.FluidChecker;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.TileUtils;
 import net.minecraft.block.Block;
@@ -604,5 +605,24 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
     @Override
     public Object[] getTanks() {
         return new Object[]{inputTank, outputTank};
+    }
+
+    //TODO: Move getSlotsForFace and isItemValidForSlot to Valve
+    //NOTE: For now it has to be in the controller as it uses the old multiblock structure so the valve's don't actually
+    //have an inventory, which causes a crash trying to insert into them
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return getController() == null ? InventoryUtils.EMPTY : new int[]{0, 1, 2, 3};
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        if (slot == 0) {
+            return FluidContainerUtils.isFluidContainer(stack) && !FluidContainerUtils.isEmpty(stack);
+        } else if (slot == 2) {
+            return FluidContainerUtils.isFluidContainer(stack) && FluidContainerUtils.isEmpty(stack);
+        }
+        return false;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
@@ -7,7 +7,6 @@ import mekanism.api.IHeatTransfer;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.util.EnumFacing;
@@ -159,12 +158,5 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
         }
 
         return super.getCapability(capability, side);
-    }
-
-    @Nonnull
-    @Override
-    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        //TODO: Improve this at some point by allowing for input output slot distinguishing
-        return getController() == null ? InventoryUtils.EMPTY : new int[]{0, 1, 2, 3};
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
@@ -7,6 +7,7 @@ import mekanism.api.IHeatTransfer;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.util.EnumFacing;
@@ -158,5 +159,12 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        //TODO: Improve this at some point by allowing for input output slot distinguishing
+        return getController() == null ? InventoryUtils.EMPTY : new int[]{0, 1, 2, 3};
     }
 }

--- a/src/main/java/mekanism/common/util/FluidContainerUtils.java
+++ b/src/main/java/mekanism/common/util/FluidContainerUtils.java
@@ -11,12 +11,26 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 public final class FluidContainerUtils {
 
     public static boolean isFluidContainer(ItemStack stack) {
         return !stack.isEmpty() && stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+    }
+
+    public static boolean isEmpty(ItemStack stack) {
+        IFluidHandlerItem handler = FluidUtil.getFluidHandler(stack);
+        if (handler != null) {
+            for (IFluidTankProperties internalTank : handler.getTankProperties()) {
+                FluidStack contents = internalTank.getContents();
+                if (contents != null && contents.amount > 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     public static FluidStack extractFluid(FluidTank tileTank, TileEntityContainerBlock tile, int slotID) {

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -66,7 +66,6 @@ public final class InventoryUtils {
         for (Map.Entry<ItemStack, Integer> requestEntry : request.itemMap.entrySet()) {
             ItemStack toInsert = requestEntry.getKey().copy();
 
-            //prioritize other implementations first to allow item forcing
             if (isItemHandler(tile, side.getOpposite())) {
                 IItemHandler inventory = getItemHandler(tile, side.getOpposite());
 

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -70,10 +70,15 @@ public final class InventoryUtils {
                 IItemHandler inventory = getItemHandler(tile, side.getOpposite());
 
                 for (int i = 0; i < inventory.getSlots(); i++) {
-                    toInsert = inventory.insertItem(i, toInsert, false);
+                    //Check validation
+                    if (inventory.isItemValid(i, toInsert)) {
+                        //Do insert
+                        toInsert = inventory.insertItem(i, toInsert, false);
 
-                    if (toInsert.isEmpty()) {
-                        return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                        //If empty, end
+                        if (toInsert.isEmpty()) {
+                            return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                        }
                     }
                 }
             } else if (tile instanceof ISidedInventory) {
@@ -336,10 +341,14 @@ public final class InventoryUtils {
             IItemHandler inventory = getItemHandler(tileEntity, side.getOpposite());
 
             for (int i = 0; i < inventory.getSlots(); i++) {
-                ItemStack rejects = inventory.insertItem(i, itemStack, true);
+                //Check validation
+                if (inventory.isItemValid(i, itemStack)) {
+                    //Simulate insert
+                    ItemStack rejects = inventory.insertItem(i, itemStack, true);
 
-                if (TransporterManager.didEmit(itemStack, rejects)) {
-                    return true;
+                    if (TransporterManager.didEmit(itemStack, rejects)) {
+                        return true;
+                    }
                 }
             }
         } else if (tileEntity instanceof ISidedInventory) {

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -10,6 +10,7 @@ import mekanism.common.content.transporter.TransitRequest;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.content.transporter.TransporterStack;
+import mekanism.common.tile.TileEntityBin;
 import mekanism.common.tile.TileEntityLogisticalSorter;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.inventory.IInventory;
@@ -29,7 +30,8 @@ public final class TransporterUtils {
             return false;
         }
 
-        if (InventoryUtils.isItemHandler(tile, side.getOpposite())) {
+        //Don't let the bin accept from all sides
+        if (!(tile instanceof TileEntityBin) && InventoryUtils.isItemHandler(tile, side.getOpposite())) {
             return true;
         } else if (tile instanceof IInventory) {
             IInventory inventory = (IInventory) tile;

--- a/src/main/java/mekanism/generators/common/tile/TileEntityWindGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityWindGenerator.java
@@ -193,4 +193,9 @@ public class TileEntityWindGenerator extends TileEntityGenerator implements IBou
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return new int[]{0};
     }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return ChargeUtils.canBeCharged(stack);
+    }
 }

--- a/src/main/java/mekanism/generators/common/tile/TileEntityWindGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityWindGenerator.java
@@ -1,9 +1,10 @@
 package mekanism.generators.common.tile;
 
 import io.netty.buffer.ByteBuf;
+import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.common.base.IBoundingBlock;
 import mekanism.api.TileNetworkList;
+import mekanism.common.base.IBoundingBlock;
 import mekanism.common.config.MekanismConfig.generators;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.MekanismUtils;
@@ -185,5 +186,11 @@ public class TileEntityWindGenerator extends TileEntityGenerator implements IBou
 
     public boolean isBlacklistDimension() {
         return isBlacklistDimension;
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return new int[]{0};
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -16,6 +16,7 @@ import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.TileUtils;
 import mekanism.generators.common.FusionReactor;
+import mekanism.generators.common.item.ItemHohlraum;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.ISound;
 import net.minecraft.item.ItemStack;
@@ -325,5 +326,10 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return isFormed() ? new int[]{0} : InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
+        return stack.getItem() instanceof ItemHohlraum;
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -3,15 +3,16 @@ package mekanism.generators.common.tile.reactor;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismFluids;
 import mekanism.common.base.IActiveState;
-import mekanism.api.TileNetworkList;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
+import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.TileUtils;
 import mekanism.generators.common.FusionReactor;
@@ -19,6 +20,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.ISound;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
@@ -317,5 +319,11 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
         }
 
         return box;
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return isFormed() ? new int[]{0} : InventoryUtils.EMPTY;
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Implement `getSlotsForFace` in various Tile Entities missing it. not having this implemented in these tile entities caused `extractItem` to fail. When we switched the priority to try using ItemHandlers first this issue was revealed by the digital miner's auto eject feature.

This also allows other mods (including minecraft with how hoppers are implemented) to interact properly with the machines that were missing it. For example you can now pump buckets into a dynamic tank via hoppers.

Edit: Also implemented `isItemValidForSlot` so that things only get inserted into the proper slots if they are able to be inserted, and obey that value for interaction with IItemHandlers in general.