### PR TITLE
Reduce idle tick time on DigitalMiner

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
+++ b/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
@@ -376,7 +376,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
               .drawString("I: " + (tileEntity.inverse ? LangUtils.localize("gui.on") : LangUtils.localize("gui.off")),
                     11, 131, 0x00CD00);
 
-        fontRenderer.drawString("Radi: " + tileEntity.radius, 11, 58, 0x00CD00);
+        fontRenderer.drawString("Radi: " + tileEntity.getRadius(), 11, 58, 0x00CD00);
 
         fontRenderer.drawString("Min: " + tileEntity.minY, 11, 83, 0x00CD00);
 

--- a/src/main/java/mekanism/client/gui/element/GuiVisualsTab.java
+++ b/src/main/java/mekanism/client/gui/element/GuiVisualsTab.java
@@ -42,7 +42,7 @@ public class GuiVisualsTab extends GuiTileEntityElement<TileEntityDigitalMiner> 
     public void renderForeground(int xAxis, int yAxis) {
         mc.renderEngine.bindTexture(RESOURCE);
         if (inBounds(xAxis, yAxis)) {
-            if (tileEntity.radius <= 64) {
+            if (tileEntity.getRadius() <= 64) {
                 displayTooltip(
                       LangUtils.localize("gui.visuals") + ": " + LangUtils.transOnOff(tileEntity.clientRendering),
                       xAxis, yAxis);

--- a/src/main/java/mekanism/client/render/MinerVisualRenderer.java
+++ b/src/main/java/mekanism/client/render/MinerVisualRenderer.java
@@ -105,7 +105,7 @@ public final class MinerVisualRenderer {
         }
 
         public MinerRenderData(TileEntityDigitalMiner miner) {
-            this(miner.minY, miner.maxY, miner.radius, miner.getPos().getY());
+            this(miner.minY, miner.maxY, miner.getRadius(), miner.getPos().getY());
         }
 
         @Override

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -85,7 +85,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public ThreadMinerSearch searcher = new ThreadMinerSearch(this);
     public double energyUsage = usage.digitalMinerUsage;
 
-    public int radius;
+    private int radius;
 
     public boolean inverse;
 
@@ -123,6 +123,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public boolean clientRendering = false;
 
     private final int[] inventorySlots;
+
+    private Set<ChunkPos> chunkSet;
 
     /**
      * This machine's current RedstoneControl type.
@@ -335,6 +337,22 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
     public int getDelay() {
         return delayLength;
+    }
+
+    public int getRadius() {
+        return radius;
+    }
+
+    public void setRadius(int newRadius) {
+        boolean changed = (radius != newRadius);
+        radius = newRadius;
+
+        // If the radius changed and we're on the server, go ahead and refresh
+        // the chunk set
+        if (changed && hasWorld() && world.isRemote) {
+            chunkSet = null;
+            getChunkSet();
+        }
     }
 
     /*
@@ -605,7 +623,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     private void readBasicData(ByteBuf dataStream) {
-        radius = dataStream.readInt();//client allowed to use whatever server sends
+        setRadius(dataStream.readInt());//client allowed to use whatever server sends
         minY = dataStream.readInt();
         maxY = dataStream.readInt();
         doEject = dataStream.readBoolean();
@@ -648,7 +666,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                     reset();
                     break;
                 case 6:
-                    radius = Math.min(dataStream.readInt(), general.digitalMinerMaxRadius);
+                    setRadius(Math.min(dataStream.readInt(), general.digitalMinerMaxRadius));
                     break;
                 case 7:
                     minY = dataStream.readInt();
@@ -1039,7 +1057,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                 return new Object[]{"Invalid parameters."};
             }
 
-            radius = Math.min(((Double) arguments[0]).intValue(), general.digitalMinerMaxRadius);
+            setRadius(Math.min(((Double) arguments[0]).intValue(), general.digitalMinerMaxRadius));
         } else if (method == 1) {
             if (arguments.length != 1 || !(arguments[0] instanceof Double)) {
                 return new Object[]{"Invalid parameters."};
@@ -1168,7 +1186,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
     @Override
     public void setConfigurationData(NBTTagCompound nbtTags) {
-        radius = Math.min(nbtTags.getInteger("radius"), general.digitalMinerMaxRadius);
+        setRadius(Math.min(nbtTags.getInteger("radius"), general.digitalMinerMaxRadius));
         minY = nbtTags.getInteger("minY");
         maxY = nbtTags.getInteger("maxY");
         doEject = nbtTags.getBoolean("doEject");
@@ -1215,7 +1233,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     @Override
     public void readSustainedData(ItemStack itemStack) {
         if (ItemDataUtils.hasData(itemStack, "hasMinerConfig")) {
-            radius = Math.min(ItemDataUtils.getInt(itemStack, "radius"), general.digitalMinerMaxRadius);
+            setRadius(Math.min(ItemDataUtils.getInt(itemStack, "radius"), general.digitalMinerMaxRadius));
             minY = ItemDataUtils.getInt(itemStack, "minY");
             maxY = ItemDataUtils.getInt(itemStack, "maxY");
             doEject = ItemDataUtils.getBoolean(itemStack, "doEject");
@@ -1299,7 +1317,12 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
     @Override
     public Set<ChunkPos> getChunkSet() {
-        return new Range4D(Coord4D.get(this)).expandFromCenter(radius).getIntersectingChunks().stream()
-              .map(Chunk3D::getPos).collect(Collectors.toSet());
+        if (chunkSet == null) {
+            chunkSet = new Range4D(Coord4D.get(this)).expandFromCenter(radius).
+                  getIntersectingChunks().stream().
+                  map(Chunk3D::getPos).collect(Collectors.toSet());
+
+        }
+        return chunkSet;
     }
 }


### PR DESCRIPTION
Reduces idle tick of DigitalMiner (issue #117) by only recalculating the chunk set when the radius changes.