### PR TITLE
Transit request overhaul

### DIFF
--- a/src/main/java/mekanism/api/Pos3D.java
+++ b/src/main/java/mekanism/api/Pos3D.java
@@ -371,8 +371,8 @@ public class Pos3D extends Vec3d {
     public boolean equals(Object obj) {
         return obj instanceof Vec3d &&
               ((Vec3d) obj).x == x &&
-              ((Vec3d) obj).x == y &&
-              ((Vec3d) obj).x == z;
+              ((Vec3d) obj).y == y &&
+              ((Vec3d) obj).z == z;
     }
 
     @Override

--- a/src/main/java/mekanism/common/content/transporter/InvStack.java
+++ b/src/main/java/mekanism/common/content/transporter/InvStack.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import mekanism.common.util.InventoryUtils;
+import mekanism.common.util.StackUtils;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -25,17 +26,17 @@ public final class InvStack {
     }
     
     public InvStack(TileEntity inv, int slotID, ItemStack stack, EnumFacing facing) {
-        this(inv, getMap(slotID, stack), facing);
+        this(inv, stack, getMap(slotID, stack), facing);
     }
 
-    public InvStack(TileEntity inv, Map<Integer, ItemStack> idMap, EnumFacing facing) {
+    public InvStack(TileEntity inv, ItemStack stack, Map<Integer, Integer> idMap, EnumFacing facing) {
         tileEntity = inv;
         itemStacks = new ArrayList<>();
         slotIDs = new ArrayList<>();
         side = facing;
 
-        for(Map.Entry<Integer, ItemStack> entry : idMap.entrySet()) {
-            appendStack(entry.getKey(), entry.getValue());
+        for(Map.Entry<Integer, Integer> entry : idMap.entrySet()) {
+            appendStack(entry.getKey(), StackUtils.size(stack, entry.getValue()));
         }
     }
 
@@ -103,9 +104,9 @@ public final class InvStack {
         use(getStack().getCount());
     }
     
-    private static Map<Integer, ItemStack> getMap(int slotID, ItemStack stack) {
-        Map<Integer, ItemStack> map = new HashMap<>();
-        map.put(slotID, stack);
+    private static Map<Integer, Integer> getMap(int slotID, ItemStack stack) {
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(slotID, stack.getCount());
         return map;
     }
 }

--- a/src/main/java/mekanism/common/content/transporter/InvStack.java
+++ b/src/main/java/mekanism/common/content/transporter/InvStack.java
@@ -1,6 +1,8 @@
 package mekanism.common.content.transporter;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import mekanism.common.util.InventoryUtils;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -21,14 +23,20 @@ public final class InvStack {
         slotIDs = new ArrayList<>();
         side = facing;
     }
+    
+    public InvStack(TileEntity inv, int slotID, ItemStack stack, EnumFacing facing) {
+        this(inv, getMap(slotID, stack), facing);
+    }
 
-    public InvStack(TileEntity inv, int id, ItemStack stack, EnumFacing facing) {
+    public InvStack(TileEntity inv, Map<Integer, ItemStack> idMap, EnumFacing facing) {
         tileEntity = inv;
         itemStacks = new ArrayList<>();
         slotIDs = new ArrayList<>();
         side = facing;
 
-        appendStack(id, stack);
+        for(Map.Entry<Integer, ItemStack> entry : idMap.entrySet()) {
+            appendStack(entry.getKey(), entry.getValue());
+        }
     }
 
     public ItemStack getStack() {
@@ -93,5 +101,11 @@ public final class InvStack {
 
     public void use() {
         use(getStack().getCount());
+    }
+    
+    private static Map<Integer, ItemStack> getMap(int slotID, ItemStack stack) {
+        Map<Integer, ItemStack> map = new HashMap<>();
+        map.put(slotID, stack);
+        return map;
     }
 }

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -60,8 +60,8 @@ public class TransitRequest {
                     if (toUse == 0)
                         continue; // continue if we don't need anymore of this item type
                     ret.addItem(StackUtils.size(stack, toUse), i);
-                    
-                    if(itemCountMap.containsKey(hashed)) {
+
+                    if (itemCountMap.containsKey(hashed)) {
                         itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
                     } else {
                         itemCountMap.put(hashed, toUse);
@@ -89,7 +89,7 @@ public class TransitRequest {
                             continue; // continue if we don't need anymore of this item type
                         ret.addItem(StackUtils.size(toSend, toUse), slotID);
 
-                        if(itemCountMap.containsKey(hashed)) {
+                        if (itemCountMap.containsKey(hashed)) {
                             itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
                         } else {
                             itemCountMap.put(hashed, toUse);
@@ -114,7 +114,7 @@ public class TransitRequest {
                             continue; // continue if we don't need anymore of this item type
                         ret.addItem(StackUtils.size(toSend, toUse), i);
 
-                        if(itemCountMap.containsKey(hashed)) {
+                        if (itemCountMap.containsKey(hashed)) {
                             itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
                         } else {
                             itemCountMap.put(hashed, toUse);
@@ -216,10 +216,12 @@ public class TransitRequest {
      *
      */
     public static class HashedItem {
-        private ItemStack itemStack;
+        private final ItemStack itemStack;
+        private final int hashCode;
 
         public HashedItem(ItemStack stack) {
             itemStack = stack;
+            hashCode = initHashCode();
         }
 
         public ItemStack getStack() {
@@ -238,6 +240,10 @@ public class TransitRequest {
 
         @Override
         public int hashCode() {
+            return hashCode;
+        }
+
+        private int initHashCode() {
             int code = 1;
             code = 31 * code + itemStack.getItem().hashCode();
             code = 31 * code + itemStack.getItemDamage();

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -193,7 +193,7 @@ public class TransitRequest {
             int code = 1;
             code = 31 * code + itemStack.getItem().hashCode();
             code = 31 * code + itemStack.getItemDamage();
-            if (itemStack.getTagCompound() != null)
+            if (itemStack.hasTagCompound())
                 code = 31 * code + itemStack.getTagCompound().hashCode();
             return code;
         }

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -2,6 +2,7 @@ package mekanism.common.content.transporter;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import mekanism.common.content.transporter.Finder.FirstFinder;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.StackUtils;
@@ -14,7 +15,11 @@ import net.minecraftforge.items.IItemHandler;
 
 public class TransitRequest {
 
-    public Map<ItemStack, Integer> itemMap = new HashMap<>();
+    /**
+     * Complicated map- associates item types with both total available item count and slot IDs and
+     * available item amounts for each slot.
+     */
+    public Map<HashedItem, Pair<Integer, Map<Integer, Integer>>> itemMap = new HashMap<>();
 
     public static TransitRequest getFromTransport(TransporterStack stack) {
         return getFromStack(stack.itemStack);
@@ -22,25 +27,37 @@ public class TransitRequest {
 
     public static TransitRequest getFromStack(ItemStack stack) {
         TransitRequest ret = new TransitRequest();
-        ret.setItem(stack, -1);
+        ret.addItem(stack, -1);
         return ret;
     }
 
-    public static TransitRequest getTopStacks(TileEntity tile, EnumFacing side, int amount) {
-        return getTopStacks(tile, side, amount, new FirstFinder());
+    public static TransitRequest buildInventoryMap(TileEntity tile, EnumFacing side, int amount) {
+        return buildInventoryMap(tile, side, amount, new FirstFinder());
     }
 
-    public static TransitRequest getTopStacks(TileEntity tile, EnumFacing side, int amount, Finder finder) {
+    /**
+     * Creates a TransitRequest based on a full inspection of an entire specified inventory from a given
+     * side. The algorithm will use the specified Finder to ensure the resulting map will only capture
+     * desired items. The amount of each item type present in the resulting item type will cap at the
+     * given 'amount' parameter.
+     */
+    public static TransitRequest buildInventoryMap(TileEntity tile, EnumFacing side, int amount, Finder finder) {
         TransitRequest ret = new TransitRequest();
-
+        // so we can keep track of how many of each item type we have in this inventory mapping
+        Map<HashedItem, Integer> itemCountMap = new HashMap<>();
+        
         if (InventoryUtils.isItemHandler(tile, side.getOpposite())) {
             IItemHandler inventory = InventoryUtils.getItemHandler(tile, side.getOpposite());
 
             for (int i = inventory.getSlots() - 1; i >= 0; i--) {
                 ItemStack stack = inventory.extractItem(i, amount, true);
 
-                if (!stack.isEmpty() && !ret.hasType(stack) && finder.modifies(stack)) {
-                    ret.setItem(stack, i);
+                if (!stack.isEmpty() && finder.modifies(stack)) {
+                    HashedItem hashed = new HashedItem(stack);
+                    int toUse = itemCountMap.containsKey(hashed) ? Math.min(stack.getCount(), amount-itemCountMap.get(hashed)) : stack.getCount();
+                    if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                    ret.addItem(StackUtils.size(stack, toUse), i);
+                    itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
                 }
             }
         } else if (tile instanceof ISidedInventory) {
@@ -51,13 +68,17 @@ public class TransitRequest {
                 int slotID = slots[get];
 
                 if (!sidedInventory.getStackInSlot(slotID).isEmpty()
-                      && sidedInventory.getStackInSlot(slotID).getCount() > 0) {
+                        && sidedInventory.getStackInSlot(slotID).getCount() > 0) {
                     ItemStack toSend = sidedInventory.getStackInSlot(slotID).copy();
                     toSend.setCount(Math.min(amount, toSend.getCount()));
 
-                    if (!ret.hasType(toSend) && sidedInventory.canExtractItem(slotID, toSend, side.getOpposite())
-                          && finder.modifies(toSend)) {
-                        ret.setItem(toSend, slotID);
+                    if (sidedInventory.canExtractItem(slotID, toSend, side.getOpposite())
+                            && finder.modifies(toSend)) {
+                        HashedItem hashed = new HashedItem(toSend);
+                        int toUse = itemCountMap.containsKey(hashed) ? Math.min(toSend.getCount(), amount-itemCountMap.get(hashed)) : toSend.getCount();
+                        if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                        ret.addItem(StackUtils.size(toSend, toUse), slotID);
+                        itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
                     }
                 }
             }
@@ -69,8 +90,12 @@ public class TransitRequest {
                     ItemStack toSend = inventory.getStackInSlot(i).copy();
                     toSend.setCount(Math.min(amount, toSend.getCount()));
 
-                    if (!ret.hasType(toSend) && finder.modifies(toSend)) {
-                        ret.setItem(toSend, i);
+                    if (finder.modifies(toSend)) {
+                        HashedItem hashed = new HashedItem(toSend);
+                        int toUse = itemCountMap.containsKey(hashed) ? Math.min(toSend.getCount(), amount-itemCountMap.get(hashed)) : toSend.getCount();
+                        if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                        ret.addItem(StackUtils.size(toSend, toUse), i);
+                        itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
                     }
                 }
             }
@@ -83,17 +108,27 @@ public class TransitRequest {
         return itemMap.isEmpty();
     }
 
-    public void setItem(ItemStack stack, int slot) {
-        itemMap.put(stack.copy(), slot);
+    public void addItem(ItemStack stack, int slot) {
+        HashedItem hashed = new HashedItem(stack);
+        if (!itemMap.containsKey(hashed)) {
+            Map<Integer, Integer> slotMap = new HashMap<>();
+            slotMap.put(slot, stack.getCount());
+            itemMap.put(hashed, Pair.of(stack.getCount(), slotMap));
+        } else {
+            int count = itemMap.get(hashed).getLeft() + stack.getCount();
+            Map<Integer, Integer> slotMap = itemMap.get(hashed).getRight();
+            slotMap.put(slot, stack.getCount());
+            itemMap.put(hashed, Pair.of(count, slotMap));
+        }
     }
 
     public ItemStack getSingleStack() {
-        return itemMap.keySet().iterator().next();
+        return itemMap.keySet().iterator().next().getStack();
     }
 
     public boolean hasType(ItemStack stack) {
-        for (ItemStack s : itemMap.keySet()) {
-            if (InventoryUtils.areItemsStackable(stack, s)) {
+        for (HashedItem item : itemMap.keySet()) {
+            if (InventoryUtils.areItemsStackable(stack, item.getStack())) {
                 return true;
             }
         }
@@ -101,28 +136,90 @@ public class TransitRequest {
         return false;
     }
 
+    /**
+     * A TransitResponse contains information regarding the partial ItemStacks which were allowed entry
+     * into a destination inventory. Note that a TransitResponse should only contain a single item type,
+     * although it may be spread out across multiple slots.
+     * 
+     * @author aidancbrady
+     *
+     */
     public static class TransitResponse {
 
-        public static final TransitResponse EMPTY = new TransitResponse(-1, ItemStack.EMPTY);
+        public static final TransitResponse EMPTY = new TransitResponse();
 
-        public int slotID;
-        public ItemStack stack;
+        /** slot ID to ItemStack map - this details how many items we will be pulling from each slot */
+        private Map<Integer, ItemStack> idMap = new HashMap<>();
+        private ItemStack toSend;
 
-        public TransitResponse(int s, ItemStack i) {
-            slotID = s;
-            stack = i;
+        private TransitResponse() {}
+
+        public TransitResponse(ItemStack i, TransitRequest request, Map<Integer, Integer> slots) {
+            toSend = i;
+
+            // generate our ID/ItemStack map based on the amount of items we're sending
+            int amount = toSend.getCount();
+            for (Map.Entry<Integer, Integer> entry : slots.entrySet()) {
+                int toUse = Math.min(amount, entry.getValue());
+                idMap.put(entry.getKey(), StackUtils.size(toSend, toUse));
+                amount -= toUse;
+                if (amount == 0)
+                    break;
+            }
+        }
+
+        public ItemStack getStack() {
+            return toSend;
         }
 
         public boolean isEmpty() {
-            return stack.isEmpty();
+            return idMap.isEmpty() || (toSend != null && toSend.isEmpty());
         }
 
         public ItemStack getRejected(ItemStack orig) {
-            return StackUtils.size(orig, orig.getCount() - stack.getCount());
+            return StackUtils.size(orig, orig.getCount() - toSend.getCount());
         }
 
         public InvStack getInvStack(TileEntity tile, EnumFacing side) {
-            return new InvStack(tile, slotID, stack, side);
+            return new InvStack(tile, idMap, side);
+        }
+    }
+
+    /**
+     * A wrapper of an ItemStack which tests equality and hashes based on item type, damage and NBT
+     * data, ignoring stack size.
+     * 
+     * @author aidancbrady
+     *
+     */
+    public static class HashedItem {
+        private ItemStack itemStack;
+
+        public HashedItem(ItemStack stack) {
+            itemStack = stack;
+        }
+
+        public ItemStack getStack() {
+            return itemStack;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof HashedItem) {
+                HashedItem other = (HashedItem) obj;
+                return InventoryUtils.areItemsStackable(itemStack, other.itemStack);
+            }
+
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            int code = 1;
+            code = 31 * code + itemStack.getItem().hashCode();
+            code = 31 * code + itemStack.getItemDamage();
+            code = 31 * code + itemStack.getTagCompound().hashCode();
+            return code;
         }
     }
 }

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -68,60 +68,6 @@ public class TransitRequest {
                     }
                 }
             }
-        } else if (tile instanceof ISidedInventory) {
-            ISidedInventory sidedInventory = (ISidedInventory) tile;
-            int[] slots = sidedInventory.getSlotsForFace(side.getOpposite());
-
-            for (int get = slots.length - 1; get >= 0; get--) {
-                int slotID = slots[get];
-
-                if (!sidedInventory.getStackInSlot(slotID).isEmpty()
-                        && sidedInventory.getStackInSlot(slotID).getCount() > 0) {
-                    ItemStack toSend = sidedInventory.getStackInSlot(slotID).copy();
-                    toSend.setCount(Math.min(amount, toSend.getCount()));
-
-                    if (sidedInventory.canExtractItem(slotID, toSend, side.getOpposite()) && finder.modifies(toSend)) {
-                        HashedItem hashed = new HashedItem(toSend);
-                        int toUse = itemCountMap.containsKey(hashed)
-                                ? Math.min(toSend.getCount(), amount - itemCountMap.get(hashed))
-                                : toSend.getCount();
-                        if (toUse == 0)
-                            continue; // continue if we don't need anymore of this item type
-                        ret.addItem(StackUtils.size(toSend, toUse), slotID);
-
-                        if (itemCountMap.containsKey(hashed)) {
-                            itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
-                        } else {
-                            itemCountMap.put(hashed, toUse);
-                        }
-                    }
-                }
-            }
-        } else if (tile instanceof IInventory) {
-            IInventory inventory = InventoryUtils.checkChestInv((IInventory) tile);
-
-            for (int i = inventory.getSizeInventory() - 1; i >= 0; i--) {
-                if (!inventory.getStackInSlot(i).isEmpty()) {
-                    ItemStack toSend = inventory.getStackInSlot(i).copy();
-                    toSend.setCount(Math.min(amount, toSend.getCount()));
-
-                    if (finder.modifies(toSend)) {
-                        HashedItem hashed = new HashedItem(toSend);
-                        int toUse = itemCountMap.containsKey(hashed)
-                                ? Math.min(toSend.getCount(), amount - itemCountMap.get(hashed))
-                                : toSend.getCount();
-                        if (toUse == 0)
-                            continue; // continue if we don't need anymore of this item type
-                        ret.addItem(StackUtils.size(toSend, toUse), i);
-
-                        if (itemCountMap.containsKey(hashed)) {
-                            itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
-                        } else {
-                            itemCountMap.put(hashed, toUse);
-                        }
-                    }
-                }
-            }
         }
 
         return ret;

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -101,7 +101,7 @@ public class TransitRequest {
             IInventory inventory = InventoryUtils.checkChestInv((IInventory) tile);
 
             for (int i = inventory.getSizeInventory() - 1; i >= 0; i--) {
-                if (!inventory.getStackInSlot(i).isEmpty() && inventory.getStackInSlot(i).getCount() > 0) {
+                if (!inventory.getStackInSlot(i).isEmpty()) {
                     ItemStack toSend = inventory.getStackInSlot(i).copy();
                     toSend.setCount(Math.min(amount, toSend.getCount()));
 
@@ -177,7 +177,7 @@ public class TransitRequest {
 
         private TransitResponse() {}
 
-        public TransitResponse(ItemStack i, TransitRequest request, Map<Integer, Integer> slots) {
+        public TransitResponse(ItemStack i, Map<Integer, Integer> slots) {
             toSend = i;
 
             // generate our ID/ItemStack map based on the amount of items we're sending

--- a/src/main/java/mekanism/common/content/transporter/TransitRequest.java
+++ b/src/main/java/mekanism/common/content/transporter/TransitRequest.java
@@ -45,7 +45,7 @@ public class TransitRequest {
         TransitRequest ret = new TransitRequest();
         // so we can keep track of how many of each item type we have in this inventory mapping
         Map<HashedItem, Integer> itemCountMap = new HashMap<>();
-        
+
         if (InventoryUtils.isItemHandler(tile, side.getOpposite())) {
             IItemHandler inventory = InventoryUtils.getItemHandler(tile, side.getOpposite());
 
@@ -54,10 +54,18 @@ public class TransitRequest {
 
                 if (!stack.isEmpty() && finder.modifies(stack)) {
                     HashedItem hashed = new HashedItem(stack);
-                    int toUse = itemCountMap.containsKey(hashed) ? Math.min(stack.getCount(), amount-itemCountMap.get(hashed)) : stack.getCount();
-                    if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                    int toUse = itemCountMap.containsKey(hashed)
+                            ? Math.min(stack.getCount(), amount - itemCountMap.get(hashed))
+                            : stack.getCount();
+                    if (toUse == 0)
+                        continue; // continue if we don't need anymore of this item type
                     ret.addItem(StackUtils.size(stack, toUse), i);
-                    itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
+                    
+                    if(itemCountMap.containsKey(hashed)) {
+                        itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
+                    } else {
+                        itemCountMap.put(hashed, toUse);
+                    }
                 }
             }
         } else if (tile instanceof ISidedInventory) {
@@ -72,13 +80,20 @@ public class TransitRequest {
                     ItemStack toSend = sidedInventory.getStackInSlot(slotID).copy();
                     toSend.setCount(Math.min(amount, toSend.getCount()));
 
-                    if (sidedInventory.canExtractItem(slotID, toSend, side.getOpposite())
-                            && finder.modifies(toSend)) {
+                    if (sidedInventory.canExtractItem(slotID, toSend, side.getOpposite()) && finder.modifies(toSend)) {
                         HashedItem hashed = new HashedItem(toSend);
-                        int toUse = itemCountMap.containsKey(hashed) ? Math.min(toSend.getCount(), amount-itemCountMap.get(hashed)) : toSend.getCount();
-                        if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                        int toUse = itemCountMap.containsKey(hashed)
+                                ? Math.min(toSend.getCount(), amount - itemCountMap.get(hashed))
+                                : toSend.getCount();
+                        if (toUse == 0)
+                            continue; // continue if we don't need anymore of this item type
                         ret.addItem(StackUtils.size(toSend, toUse), slotID);
-                        itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
+
+                        if(itemCountMap.containsKey(hashed)) {
+                            itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
+                        } else {
+                            itemCountMap.put(hashed, toUse);
+                        }
                     }
                 }
             }
@@ -92,10 +107,18 @@ public class TransitRequest {
 
                     if (finder.modifies(toSend)) {
                         HashedItem hashed = new HashedItem(toSend);
-                        int toUse = itemCountMap.containsKey(hashed) ? Math.min(toSend.getCount(), amount-itemCountMap.get(hashed)) : toSend.getCount();
-                        if(toUse == 0) continue; // continue if we don't need anymore of this item type
+                        int toUse = itemCountMap.containsKey(hashed)
+                                ? Math.min(toSend.getCount(), amount - itemCountMap.get(hashed))
+                                : toSend.getCount();
+                        if (toUse == 0)
+                            continue; // continue if we don't need anymore of this item type
                         ret.addItem(StackUtils.size(toSend, toUse), i);
-                        itemCountMap.put(hashed, itemCountMap.get(hashed)+toUse);
+
+                        if(itemCountMap.containsKey(hashed)) {
+                            itemCountMap.put(hashed, itemCountMap.get(hashed) + toUse);
+                        } else {
+                            itemCountMap.put(hashed, toUse);
+                        }
                     }
                 }
             }
@@ -218,7 +241,8 @@ public class TransitRequest {
             int code = 1;
             code = 31 * code + itemStack.getItem().hashCode();
             code = 31 * code + itemStack.getItemDamage();
-            code = 31 * code + itemStack.getTagCompound().hashCode();
+            if (itemStack.getTagCompound() != null)
+                code = 31 * code + itemStack.getTagCompound().hashCode();
             return code;
         }
     }

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -184,7 +184,7 @@ public class TransporterManager {
         // Now for each of the items in the request, simulate the insert, using the state from all the in-flight
         // items to ensure we have an accurate model of what will happen in future. We try each stack in the
         // request; it might be possible to not send the first item, but the second could work, etc.
-        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.itemMap.entrySet()) {
+        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.getItemMap().entrySet()) {
             // Create a sending ItemStack with the hashed item type and total item count within the request
             ItemStack toSend = StackUtils.size(requestEntry.getKey().getStack(), requestEntry.getValue().getLeft());
             ItemStack leftovers = simulateInsert(handler, invCopy, side, toSend.copy());

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -196,7 +196,7 @@ public class TransporterManager {
 
             // Otherwise, construct the appropriately size stack to send and return that
             toSend.setCount(toSend.getCount() - leftovers.getCount());
-            return new TransitResponse(toSend, request, requestEntry.getValue().getRight());
+            return new TransitResponse(toSend, requestEntry.getValue().getRight());
         }
 
         return TransitResponse.EMPTY;

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -6,10 +6,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ISideConfiguration;
+import mekanism.common.content.transporter.TransitRequest.HashedItem;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterStack.Path;
 import mekanism.common.util.InventoryUtils;
@@ -182,18 +184,19 @@ public class TransporterManager {
         // Now for each of the items in the request, simulate the insert, using the state from all the in-flight
         // items to ensure we have an accurate model of what will happen in future. We try each stack in the
         // request; it might be possible to not send the first item, but the second could work, etc.
-        for (Map.Entry<ItemStack, Integer> requestEntry : request.itemMap.entrySet()) {
-            ItemStack leftovers = simulateInsert(handler, invCopy, side, requestEntry.getKey().copy());
+        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.itemMap.entrySet()) {
+            // Create a sending ItemStack with the hashed item type and total item count within the request
+            ItemStack toSend = StackUtils.size(requestEntry.getKey().getStack(), requestEntry.getValue().getLeft());
+            ItemStack leftovers = simulateInsert(handler, invCopy, side, toSend.copy());
 
             // If leftovers is unchanged from the simulation, there's no room at all; move on to the next stack
-            if (ItemStack.areItemStacksEqual(leftovers, requestEntry.getKey())) {
+            if (ItemStack.areItemStacksEqual(leftovers, toSend)) {
                 continue;
             }
 
             // Otherwise, construct the appropriately size stack to send and return that
-            ItemStack stackToSend = requestEntry.getKey().copy();
-            stackToSend.setCount(requestEntry.getKey().getCount() - leftovers.getCount());
-            return new TransitResponse(requestEntry.getValue(), stackToSend);
+            toSend.setCount(toSend.getCount() - leftovers.getCount());
+            return new TransitResponse(toSend, request, requestEntry.getValue().getRight());
         }
 
         return TransitResponse.EMPTY;

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -43,7 +43,7 @@ public final class TransporterPathfinder {
             DestChecker checker = new DestChecker() {
                 @Override
                 public boolean isValid(TransporterStack stack, EnumFacing dir, TileEntity tile) {
-                    return InventoryUtils.canInsert(tile, stack.color, entry.response.stack, dir, false);
+                    return InventoryUtils.canInsert(tile, stack.color, entry.response.getStack(), dir, false);
                 }
             };
 
@@ -80,7 +80,7 @@ public final class TransporterPathfinder {
 
     public static Destination getPath(DestChecker checker, EnumSet<EnumFacing> sides, ILogisticalTransporter start,
           Coord4D dest, TransporterStack stack, TransitResponse response, int min) {
-        if (response.stack.getCount() >= min) {
+        if (response.getStack().getCount() >= min) {
             List<Coord4D> test = PathfinderCache.getCache(start.coord(), dest, sides);
 
             if (test != null && checkPath(start.world(), test, stack)) {

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -238,7 +238,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
                               .insert(this, transporter, TransitRequest.getFromStack(bottomStack), null, true, 0);
 
                         if (!response.isEmpty()) {
-                            bottomStack.shrink(response.stack.getCount());
+                            bottomStack.shrink(response.getStack().getCount());
                             setInventorySlotContents(0, bottomStack);
                         }
                     } else {
@@ -247,7 +247,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
                                     false);
 
                         if (!response.isEmpty()) {
-                            bottomStack.shrink(response.stack.getCount());
+                            bottomStack.shrink(response.getStack().getCount());
                             setInventorySlotContents(0, bottomStack);
                         }
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -430,7 +430,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                 }
 
                 if (!request.hasType(stack)) {
-                    request.setItem(stack, i);
+                    request.addItem(stack, i);
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -115,7 +115,7 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
                             TransitResponse response = emitItemToTransporter(front, request, filter.color, min);
 
                             if (!response.isEmpty()) {
-                                invStack.use(response.stack.getCount());
+                                invStack.use(response.getStack().getCount());
                                 back.markDirty();
                                 setActive(true);
                                 sentItems = true;
@@ -128,11 +128,11 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
 
                 if (!sentItems && autoEject) {
                     TransitRequest request = TransitRequest
-                          .getTopStacks(back, facing.getOpposite(), 64, new StrictFilterFinder());
+                          .buildInventoryMap(back, facing.getOpposite(), 64, new StrictFilterFinder());
                     TransitResponse response = emitItemToTransporter(front, request, color, 0);
 
                     if (!response.isEmpty()) {
-                        response.getInvStack(back, facing).use(response.stack.getCount());
+                        response.getInvStack(back, facing).use(response.getStack().getCount());
                         back.markDirty();
                         setActive(true);
                     }

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -172,14 +172,14 @@ public class TileComponentEjector implements ITileComponent {
                           TransitRequest.getFromStack(stack.copy()), outputColor, true, 0);
 
                     if (!response.isEmpty()) {
-                        stack.shrink(response.stack.getCount());
+                        stack.shrink(response.getStack().getCount());
                     }
                 } else {
                     TransitResponse response = InventoryUtils
                           .putStackInInventory(tile, TransitRequest.getFromStack(stack.copy()), side, false);
 
                     if (!response.isEmpty()) {
-                        stack.shrink(response.stack.getCount());
+                        stack.shrink(response.getStack().getCount());
                     }
                 }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -134,7 +134,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         // Attempt to pull
         for (EnumFacing side : getConnections(ConnectionType.PULL)) {
             TileEntity tile = getWorld().getTileEntity(getPos().offset(side));
-            TransitRequest request = TransitRequest.getTopStacks(tile, side, tier.pullAmount);
+            TransitRequest request = TransitRequest.buildInventoryMap(tile, side, tier.pullAmount);
 
             // There's a stack available to insert into the network...
             if (!request.isEmpty()) {
@@ -143,7 +143,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
 
                 // If the insert succeeded, remove the inserted count and try again for another 10 ticks
                 if (!response.isEmpty()) {
-                    response.getInvStack(tile, side.getOpposite()).use(response.stack.getCount());
+                    response.getInvStack(tile, side.getOpposite()).use(response.getStack().getCount());
                     delay = 10;
                 } else {
                     // Insert failed; increment the backoff and calculate delay. Note that we cap retries

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -247,7 +247,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         TransitResponse response = stack.recalculatePath(request, this, min);
 
         if (!response.isEmpty()) {
-            stack.itemStack = response.stack;
+            stack.itemStack = response.getStack();
 
             if (doEmit) {
                 transit.add(stack);
@@ -280,7 +280,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         TransitResponse response = stack.recalculateRRPath(request, outputter, this, min);
 
         if (!response.isEmpty()) {
-            stack.itemStack = response.stack;
+            stack.itemStack = response.getStack();
 
             if (doEmit) {
                 transit.add(stack);

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -1,10 +1,12 @@
 package mekanism.common.util;
 
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import mekanism.api.EnumColor;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.content.transporter.InvStack;
 import mekanism.common.content.transporter.TransitRequest;
+import mekanism.common.content.transporter.TransitRequest.HashedItem;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.tile.TileEntityBin;
@@ -21,7 +23,7 @@ import net.minecraftforge.items.IItemHandler;
 
 public final class InventoryUtils {
 
-    public static final int[] EMPTY = new int[]{};
+    public static final int[] EMPTY = new int[] {};
 
     public static int[] getIntRange(int start, int end) {
         int[] ret = new int[1 + end - start];
@@ -57,26 +59,27 @@ public final class InventoryUtils {
     }
 
     public static TransitResponse putStackInInventory(TileEntity tile, TransitRequest request, EnumFacing side,
-          boolean force) {
+            boolean force) {
         if (force && tile instanceof TileEntityLogisticalSorter) {
             return ((TileEntityLogisticalSorter) tile).sendHome(request.getSingleStack());
         }
 
-        for (Map.Entry<ItemStack, Integer> requestEntry : request.itemMap.entrySet()) {
-            ItemStack toInsert = requestEntry.getKey().copy();
+        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.itemMap.entrySet()) {
+            ItemStack origInsert = StackUtils.size(requestEntry.getKey().getStack(), requestEntry.getValue().getLeft());
+            ItemStack toInsert = origInsert.copy();
 
             if (isItemHandler(tile, side.getOpposite())) {
                 IItemHandler inventory = getItemHandler(tile, side.getOpposite());
 
                 for (int i = 0; i < inventory.getSlots(); i++) {
-                    //Check validation
+                    // Check validation
                     if (inventory.isItemValid(i, toInsert)) {
-                        //Do insert
+                        // Do insert
                         toInsert = inventory.insertItem(i, toInsert, false);
 
-                        //If empty, end
+                        // If empty, end
                         if (toInsert.isEmpty()) {
-                            return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
                         }
                     }
                 }
@@ -93,8 +96,8 @@ public final class InventoryUtils {
                         int slotID = slots[get];
 
                         if (!force) {
-                            if (!sidedInventory.isItemValidForSlot(slotID, toInsert) || !sidedInventory
-                                  .canInsertItem(slotID, toInsert, side.getOpposite())) {
+                            if (!sidedInventory.isItemValidForSlot(slotID, toInsert)
+                                    || !sidedInventory.canInsertItem(slotID, toInsert, side.getOpposite())) {
                                 continue;
                             }
                         }
@@ -106,7 +109,7 @@ public final class InventoryUtils {
                                 sidedInventory.setInventorySlotContents(slotID, toInsert);
                                 sidedInventory.markDirty();
 
-                                return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                                return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
                             } else {
                                 int rejects = toInsert.getCount() - sidedInventory.getInventoryStackLimit();
 
@@ -122,7 +125,7 @@ public final class InventoryUtils {
                                 toInsert = remains;
                             }
                         } else if (areItemsStackable(toInsert, inSlot) && inSlot.getCount() < Math
-                              .min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit())) {
+                                .min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit())) {
                             int max = Math.min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit());
 
                             if (inSlot.getCount() + toInsert.getCount() <= max) {
@@ -132,7 +135,7 @@ public final class InventoryUtils {
                                 sidedInventory.setInventorySlotContents(slotID, toSet);
                                 sidedInventory.markDirty();
 
-                                return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                                return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
                             } else {
                                 int rejects = (inSlot.getCount() + toInsert.getCount()) - max;
 
@@ -167,7 +170,7 @@ public final class InventoryUtils {
                             inventory.setInventorySlotContents(i, toInsert);
                             inventory.markDirty();
 
-                            return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
                         } else {
                             int rejects = toInsert.getCount() - inventory.getInventoryStackLimit();
 
@@ -183,7 +186,7 @@ public final class InventoryUtils {
                             toInsert = remains;
                         }
                     } else if (areItemsStackable(toInsert, inSlot) && inSlot.getCount() < Math
-                          .min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit())) {
+                            .min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit())) {
                         int max = Math.min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit());
 
                         if (inSlot.getCount() + toInsert.getCount() <= max) {
@@ -193,7 +196,7 @@ public final class InventoryUtils {
                             inventory.setInventorySlotContents(i, toSet);
                             inventory.markDirty();
 
-                            return new TransitResponse(requestEntry.getValue(), requestEntry.getKey());
+                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
                         } else {
                             int rejects = (inSlot.getCount() + toInsert.getCount()) - max;
 
@@ -212,9 +215,9 @@ public final class InventoryUtils {
                 }
             }
 
-            if (TransporterManager.didEmit(requestEntry.getKey(), toInsert)) {
-                return new TransitResponse(requestEntry.getValue(),
-                      TransporterManager.getToUse(requestEntry.getKey(), toInsert));
+            if (TransporterManager.didEmit(origInsert, toInsert)) {
+                return new TransitResponse(TransporterManager.getToUse(origInsert, toInsert), request,
+                        requestEntry.getValue().getRight());
             }
         }
 
@@ -262,8 +265,8 @@ public final class InventoryUtils {
                 for (int get = slots.length - 1; get >= 0; get--) {
                     int slotID = slots[get];
 
-                    if (!sidedInventory.getStackInSlot(slotID).isEmpty() && StackUtils
-                          .equalsWildcard(sidedInventory.getStackInSlot(slotID), type)) {
+                    if (!sidedInventory.getStackInSlot(slotID).isEmpty()
+                            && StackUtils.equalsWildcard(sidedInventory.getStackInSlot(slotID), type)) {
                         ItemStack stack = sidedInventory.getStackInSlot(slotID);
                         int current = !ret.getStack().isEmpty() ? ret.getStack().getCount() : 0;
 
@@ -292,8 +295,8 @@ public final class InventoryUtils {
             IInventory inventory = checkChestInv((IInventory) tile);
 
             for (int i = inventory.getSizeInventory() - 1; i >= 0; i--) {
-                if (!inventory.getStackInSlot(i).isEmpty() && StackUtils
-                      .equalsWildcard(inventory.getStackInSlot(i), type)) {
+                if (!inventory.getStackInSlot(i).isEmpty()
+                        && StackUtils.equalsWildcard(inventory.getStackInSlot(i), type)) {
                     ItemStack stack = inventory.getStackInSlot(i);
                     int current = !ret.getStack().isEmpty() ? ret.getStack().getCount() : 0;
 
@@ -320,7 +323,7 @@ public final class InventoryUtils {
     }
 
     public static boolean canInsert(TileEntity tileEntity, EnumColor color, ItemStack itemStack, EnumFacing side,
-          boolean force) {
+            boolean force) {
         if (force && tileEntity instanceof TileEntityLogisticalSorter) {
             return ((TileEntityLogisticalSorter) tileEntity).canSendHome(itemStack);
         }
@@ -328,8 +331,8 @@ public final class InventoryUtils {
         if (!force && tileEntity instanceof ISideConfiguration) {
             ISideConfiguration config = (ISideConfiguration) tileEntity;
             EnumFacing tileSide = config.getOrientation();
-            EnumColor configColor = config.getEjector()
-                  .getInputColor(MekanismUtils.getBaseOrientation(side, tileSide).getOpposite());
+            EnumColor configColor =
+                    config.getEjector().getInputColor(MekanismUtils.getBaseOrientation(side, tileSide).getOpposite());
 
             if (config.getEjector().hasStrictInput() && configColor != null && configColor != color) {
                 return false;
@@ -340,9 +343,9 @@ public final class InventoryUtils {
             IItemHandler inventory = getItemHandler(tileEntity, side.getOpposite());
 
             for (int i = 0; i < inventory.getSlots(); i++) {
-                //Check validation
+                // Check validation
                 if (inventory.isItemValid(i, itemStack)) {
-                    //Simulate insert
+                    // Simulate insert
                     ItemStack rejects = inventory.insertItem(i, itemStack, true);
 
                     if (TransporterManager.didEmit(itemStack, rejects)) {
@@ -363,8 +366,8 @@ public final class InventoryUtils {
                     int slotID = slots[get];
 
                     if (!force) {
-                        if (!sidedInventory.isItemValidForSlot(slotID, itemStack) || !sidedInventory
-                              .canInsertItem(slotID, itemStack, side.getOpposite())) {
+                        if (!sidedInventory.isItemValidForSlot(slotID, itemStack)
+                                || !sidedInventory.canInsertItem(slotID, itemStack, side.getOpposite())) {
                             continue;
                         }
                     }
@@ -382,7 +385,7 @@ public final class InventoryUtils {
                             }
                         }
                     } else if (areItemsStackable(itemStack, inSlot) && inSlot.getCount() < Math
-                          .min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit())) {
+                            .min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit())) {
                         int max = Math.min(inSlot.getMaxStackSize(), sidedInventory.getInventoryStackLimit());
 
                         if (inSlot.getCount() + itemStack.getCount() <= max) {
@@ -419,8 +422,8 @@ public final class InventoryUtils {
                             return true;
                         }
                     }
-                } else if (areItemsStackable(itemStack, inSlot) && inSlot.getCount() < Math
-                      .min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit())) {
+                } else if (areItemsStackable(itemStack, inSlot)
+                        && inSlot.getCount() < Math.min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit())) {
                     int max = Math.min(inSlot.getMaxStackSize(), inventory.getInventoryStackLimit());
 
                     if (inSlot.getCount() + itemStack.getCount() <= max) {
@@ -447,12 +450,11 @@ public final class InventoryUtils {
         return CapabilityUtils.getCapability(tile, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
     }
 
-    /*TODO From CCLib -- go back to that version when we're using dependencies again*/
+    /* TODO From CCLib -- go back to that version when we're using dependencies again */
     public static boolean canStack(ItemStack stack1, ItemStack stack2) {
-        return stack1.isEmpty() || stack2.isEmpty() ||
-              (stack1.getItem() == stack2.getItem() &&
-                    (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage()) &&
-                    ItemStack.areItemStackTagsEqual(stack2, stack1)) &&
-                    stack1.isStackable();
+        return stack1.isEmpty() || stack2.isEmpty()
+                || (stack1.getItem() == stack2.getItem()
+                        && (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage())
+                        && ItemStack.areItemStackTagsEqual(stack2, stack1)) && stack1.isStackable();
     }
 }

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -64,7 +64,7 @@ public final class InventoryUtils {
             return ((TileEntityLogisticalSorter) tile).sendHome(request.getSingleStack());
         }
 
-        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.itemMap.entrySet()) {
+        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.getItemMap().entrySet()) {
             ItemStack origInsert = StackUtils.size(requestEntry.getKey().getStack(), requestEntry.getValue().getLeft());
             ItemStack toInsert = origInsert.copy();
 

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -79,7 +79,7 @@ public final class InventoryUtils {
 
                         // If empty, end
                         if (toInsert.isEmpty()) {
-                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
+                            return new TransitResponse(origInsert, requestEntry.getValue().getRight());
                         }
                     }
                 }
@@ -109,7 +109,7 @@ public final class InventoryUtils {
                                 sidedInventory.setInventorySlotContents(slotID, toInsert);
                                 sidedInventory.markDirty();
 
-                                return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
+                                return new TransitResponse(origInsert, requestEntry.getValue().getRight());
                             } else {
                                 int rejects = toInsert.getCount() - sidedInventory.getInventoryStackLimit();
 
@@ -135,7 +135,7 @@ public final class InventoryUtils {
                                 sidedInventory.setInventorySlotContents(slotID, toSet);
                                 sidedInventory.markDirty();
 
-                                return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
+                                return new TransitResponse(origInsert, requestEntry.getValue().getRight());
                             } else {
                                 int rejects = (inSlot.getCount() + toInsert.getCount()) - max;
 
@@ -170,7 +170,7 @@ public final class InventoryUtils {
                             inventory.setInventorySlotContents(i, toInsert);
                             inventory.markDirty();
 
-                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
+                            return new TransitResponse(origInsert, requestEntry.getValue().getRight());
                         } else {
                             int rejects = toInsert.getCount() - inventory.getInventoryStackLimit();
 
@@ -196,7 +196,7 @@ public final class InventoryUtils {
                             inventory.setInventorySlotContents(i, toSet);
                             inventory.markDirty();
 
-                            return new TransitResponse(origInsert, request, requestEntry.getValue().getRight());
+                            return new TransitResponse(origInsert, requestEntry.getValue().getRight());
                         } else {
                             int rejects = (inSlot.getCount() + toInsert.getCount()) - max;
 
@@ -216,7 +216,7 @@ public final class InventoryUtils {
             }
 
             if (TransporterManager.didEmit(origInsert, toInsert)) {
-                return new TransitResponse(TransporterManager.getToUse(origInsert, toInsert), request,
+                return new TransitResponse(TransporterManager.getToUse(origInsert, toInsert),
                         requestEntry.getValue().getRight());
             }
         }


### PR DESCRIPTION
### Summary

This PR makes major modifications to TransitRequests and TransitResponses to allow homogenous items to be pulled from multiple slots with mechanisms such as pulling Logistical Transporters and Logistical Sorters.  A brief, bulleted summary of the changes:

- TransitRequests now track origin inventories with a HashMap linking item types to their respective slot-based locations. This is done with the following data structure:
`Map<HashedItem, Pair<Integer, Map<Integer, Integer>>>`
HashedItem is a hashed form of an ItemStack that doesn't track stack size. These are mapped to a Pair which contains (left) a totaled count of the specified item type, and (right) a map associating each slot ID containing that item type to the slot's respective ItemStack.
- `getTopStacks()` has been replaced with `buildInventoryMap()`, which scans the entire inventory (instead of just the top stacks of each item type) and creates an itemMap with will track up to a specified amount of each item type within the origin inventory.
- TransitReponse now uses a map (`Map<Integer, ItemStack>`) associating each slot ID of the origin inventory with an ItemStack representing how much of the item will be used up by the inventory pull. Note that unlike TransitRequest which can store all the different item types within an inventory, a TransitResponse should **only contain slots/ItemStacks associated with a homogenous item type.** This map will be created at object creation, and the resulting mapped ItemStacks will be scaled to match the amount of the item to be used by the TransitRequest.

### Functionality Changes

These changes should make pulling from inventories with spread-out items much more efficient. Take an example of a chest with the following contents in the first few slots:
* `10C  10C  10C  10C`, where C is cobblestone

Previous to these changes, this setup would result in an Ultimate Logistical Transporter having four different pull operations of 10C each. This overhaul should now consolidate all four of these stacks and export them in a single pull operation (resulting in a stack of 40C).

### To Test

* Dispersed (sub-64) ItemStacks of multiple types- will the items properly merge and ship in consolidated stacks?
* Different inventories- will multiple ItemStacks be appropriately removed from both Vanilla and inventories from other mods?

Ultimately, messing around with Logistical Transporters in general should find shortcomings of this system relatively quickly if there are any.