### PR TITLE
Use per-stack IDs for batch deletes in network protocol

### DIFF
--- a/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
@@ -6,6 +6,7 @@ import mekanism.client.model.ModelTransporterBox;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.client.render.MekanismRenderer.DisplayInteger;
 import mekanism.client.render.MekanismRenderer.Model3D;
+import mekanism.common.Mekanism;
 import mekanism.common.config.MekanismConfig.client;
 import mekanism.common.content.transporter.TransporterStack;
 import mekanism.common.item.ItemConfigurator;
@@ -67,7 +68,7 @@ public class RenderLogisticalTransporter extends RenderTransmitterBase<TileEntit
               transporter.getPos().getZ() + 0.5);
         entityItem.world = transporter.getWorld();
 
-        for (TransporterStack stack : transporter.getTransmitter().transit.clone()) {
+        for (TransporterStack stack : transporter.getTransmitter().getTransit()) {
             if (stack != null) {
                 GL11.glPushMatrix();
                 entityItem.setItem(stack.itemStack);

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -38,6 +38,22 @@ public class TransporterStack {
     public Path pathType;
     private List<Coord4D> pathToTarget = new ArrayList<>();
 
+    private int id;
+
+    protected TransporterStack() {}
+
+    public TransporterStack(int id) {
+        this.id = id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
     public static TransporterStack readFromNBT(NBTTagCompound nbtTags) {
         TransporterStack stack = new TransporterStack();
         stack.read(nbtTags);
@@ -59,6 +75,7 @@ public class TransporterStack {
             data.add(-1);
         }
 
+        data.add(id);
         data.add(progress);
         originalLocation.write(data);
         data.add(pathType.ordinal());
@@ -84,6 +101,8 @@ public class TransporterStack {
             color = null;
         }
 
+        id = dataStream.readInt();
+
         progress = dataStream.readInt();
         originalLocation = Coord4D.read(dataStream);
         pathType = Path.values()[dataStream.readInt()];
@@ -102,6 +121,7 @@ public class TransporterStack {
             nbtTags.setInteger("color", TransporterUtils.colors.indexOf(color));
         }
 
+        nbtTags.setInteger("id", id);
         nbtTags.setInteger("progress", progress);
         nbtTags.setTag("originalLocation", originalLocation.write(new NBTTagCompound()));
 
@@ -122,6 +142,7 @@ public class TransporterStack {
             color = TransporterUtils.colors.get(nbtTags.getInteger("color"));
         }
 
+        id = nbtTags.getInteger("id");
         progress = nbtTags.getInteger("progress");
         originalLocation = Coord4D.read(nbtTags.getCompoundTag("originalLocation"));
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -38,21 +38,7 @@ public class TransporterStack {
     public Path pathType;
     private List<Coord4D> pathToTarget = new ArrayList<>();
 
-    private int id;
-
     protected TransporterStack() {}
-
-    public TransporterStack(int id) {
-        this.id = id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getId() {
-        return id;
-    }
 
     public static TransporterStack readFromNBT(NBTTagCompound nbtTags) {
         TransporterStack stack = new TransporterStack();
@@ -75,7 +61,6 @@ public class TransporterStack {
             data.add(-1);
         }
 
-        data.add(id);
         data.add(progress);
         originalLocation.write(data);
         data.add(pathType.ordinal());
@@ -101,8 +86,6 @@ public class TransporterStack {
             color = null;
         }
 
-        id = dataStream.readInt();
-
         progress = dataStream.readInt();
         originalLocation = Coord4D.read(dataStream);
         pathType = Path.values()[dataStream.readInt()];
@@ -121,7 +104,6 @@ public class TransporterStack {
             nbtTags.setInteger("color", TransporterUtils.colors.indexOf(color));
         }
 
-        nbtTags.setInteger("id", id);
         nbtTags.setInteger("progress", progress);
         nbtTags.setTag("originalLocation", originalLocation.write(new NBTTagCompound()));
 
@@ -142,7 +124,6 @@ public class TransporterStack {
             color = TransporterUtils.colors.get(nbtTags.getInteger("color"));
         }
 
-        id = nbtTags.getInteger("id");
         progress = nbtTags.getInteger("progress");
         originalLocation = Coord4D.read(nbtTags.getCompoundTag("originalLocation"));
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -38,8 +38,6 @@ public class TransporterStack {
     public Path pathType;
     private List<Coord4D> pathToTarget = new ArrayList<>();
 
-    public TransporterStack() {}
-
     public static TransporterStack readFromNBT(NBTTagCompound nbtTags) {
         TransporterStack stack = new TransporterStack();
         stack.read(nbtTags);

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -38,7 +38,7 @@ public class TransporterStack {
     public Path pathType;
     private List<Coord4D> pathToTarget = new ArrayList<>();
 
-    protected TransporterStack() {}
+    public TransporterStack() {}
 
     public static TransporterStack readFromNBT(NBTTagCompound nbtTags) {
         TransporterStack stack = new TransporterStack();

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
@@ -86,7 +86,7 @@ public class TileEntityDiversionTransporter extends TileEntityLogisticalTranspor
     }
 
     @Override
-    public TileNetworkList makeBatchPacket(Set<TransporterStack> updates, Set<TransporterStack> deletes) {
+    public TileNetworkList makeBatchPacket(Set<TransporterStack> updates, Set<Integer> deletes) {
         return addModes(super.makeBatchPacket(updates, deletes));
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
@@ -1,6 +1,7 @@
 package mekanism.common.tile.transmitter;
 
 import io.netty.buffer.ByteBuf;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
@@ -81,12 +82,12 @@ public class TileEntityDiversionTransporter extends TileEntityLogisticalTranspor
     }
 
     @Override
-    public TileNetworkList makeSyncPacket(TransporterStack stack) {
-        return addModes(super.makeSyncPacket(stack));
+    public TileNetworkList makeSyncPacket(int stackId, TransporterStack stack) {
+        return addModes(super.makeSyncPacket(stackId, stack));
     }
 
     @Override
-    public TileNetworkList makeBatchPacket(Set<TransporterStack> updates, Set<Integer> deletes) {
+    public TileNetworkList makeBatchPacket(Map<Integer, TransporterStack> updates, Set<Integer> deletes) {
         return addModes(super.makeBatchPacket(updates, deletes));
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -1,9 +1,7 @@
 package mekanism.common.tile.transmitter;
 
 import io.netty.buffer.ByteBuf;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -11,13 +9,13 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.Tier;
 import mekanism.common.Tier.BaseTier;
 import mekanism.common.Tier.TransporterTier;
 import mekanism.common.base.ILogisticalTransporter;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.property.PropertyColor;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
@@ -43,7 +41,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.property.IExtendedBlockState;
-import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileEntity, InventoryNetwork> {
@@ -273,9 +270,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         }
 
         data.add(deletes.size());
-        for (Integer id : deletes) {
-            data.add(id);
-        }
+        data.addAll(deletes);
 
         return data;
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -231,11 +231,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         }
 
         // Serialize all the in-flight stacks (this includes their ID)
-        Collection<TransporterStack> stacks = getTransmitter().getTransit();
-        data.add(stacks.size());
-        for (TransporterStack stack : stacks) {
-            stack.write(getTransmitter(), data);
-        }
+        getTransmitter().writeToPacket(data);
 
         return data;
     }

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -1,18 +1,15 @@
 package mekanism.common.transmitters;
 
 import io.netty.buffer.ByteBuf;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.Range4D;
-import mekanism.common.HashList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.capabilities.Capabilities;
@@ -217,17 +214,14 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                 }
             }
 
-            // Remove any packets from needsSync that are also queued up for removal; there tends to be a large
-            // overlap between updates and deletes. This suggests that we are being too aggressive on adding
-            // to needsSync
-            // TODO: Investigate why the overlap is so large
-            deletes.stream().forEach(id -> needsSync.remove(id));
-
             if (deletes.size() > 0 || needsSync.size() > 0) {
+                // TODO: Rework above so that we are guaranteed that there is no overlap between deletes/needsSync
+                deletes.forEach(id -> needsSync.remove(id));
+
                 TileEntityMessage msg = new TileEntityMessage(coord(), getTileEntity().makeBatchPacket(needsSync, deletes));
 
                 // Now remove any entries from transit that have been deleted
-                deletes.stream().forEach(id -> transit.remove(id));
+                deletes.forEach(id -> transit.remove(id));
 
                 // Clear the pending sync packets
                 needsSync.clear();

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -143,33 +143,33 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                                 ILogisticalTransporter nextTile = CapabilityUtils
                                       .getCapability(next.getTileEntity(world()),
                                             Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null);
-                                nextTile.entityEntering(stack, stack.progress % 100);
+                                if (nextTile != null) {
+                                    nextTile.entityEntering(stack, stack.progress % 100);
+                                }
                                 deletes.add(stackId);
 
                                 continue;
                             } else if (next != null) {
                                 prevSet = next;
                             }
-                        } else {
-                            if (stack.pathType != Path.NONE) {
-                                TileEntity tile = next.getTileEntity(world());
+                        } else if (stack.pathType != Path.NONE) {
+                            TileEntity tile = next.getTileEntity(world());
 
-                                if (tile != null) {
-                                    TransitResponse response = InventoryUtils
-                                          .putStackInInventory(tile, TransitRequest.getFromTransport(stack),
-                                                stack.getSide(this), stack.pathType == Path.HOME);
+                            if (tile != null) {
+                                TransitResponse response = InventoryUtils
+                                      .putStackInInventory(tile, TransitRequest.getFromTransport(stack),
+                                            stack.getSide(this), stack.pathType == Path.HOME);
 
-                                    if (response.getRejected(stack.itemStack).isEmpty()) {
-                                        TransporterManager.remove(stack);
-                                        deletes.add(stackId);
-                                        continue;
-                                    } else {
-                                        //Don't add it ot needsSync here because it will be added in the below
-                                        // recalculate statement and then added or added to deletes
-                                        stack.itemStack = response.getRejected(stack.itemStack);
+                                if (response.getRejected(stack.itemStack).isEmpty()) {
+                                    TransporterManager.remove(stack);
+                                    deletes.add(stackId);
+                                    continue;
+                                } else {
+                                    //Don't add it ot needsSync here because it will be added in the below
+                                    // recalculate statement and then added or added to deletes
+                                    stack.itemStack = response.getRejected(stack.itemStack);
 
-                                        prevSet = next;
-                                    }
+                                    prevSet = next;
                                 }
                             }
                         }
@@ -331,7 +331,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         int stackId = nextId++;
         stack.progress = progress;
         transit.put(stackId, stack);
-        //Don't add to needsSync as the only place this gets called immediately adds it to deletes afterwards
+        needsSync.put(stackId, stack);
 
         // N.B. We are not marking the chunk as dirty here! I don't believe it's needed, since
         // the next tick will generate the necessary save and if we crash before the next tick,


### PR DESCRIPTION
Batch deletions do not currently work properly since they assume indicies don't change during a deletion. This PR introduces per-stack IDs on a per-tile basis to allow us to pass IDs instead of indicies and thus avoid problems where deletion of id zero throws off the remaining batch deletes.