### PR TITLE
Improve handling and exposing of Capabilities

### DIFF
--- a/src/main/java/mekanism/api/gas/ITubeConnection.java
+++ b/src/main/java/mekanism/api/gas/ITubeConnection.java
@@ -6,7 +6,10 @@ import net.minecraft.util.EnumFacing;
  * Implement this if your block can connect to Pressurized Tubes.
  *
  * @author AidanBrady
+ * @deprecated Dropped in favor of better support for machines of what implements GAS_HANDLER_CAPABILITY use {@link
+ * IGasHandler} instead.
  */
+@Deprecated
 public interface ITubeConnection {
 
     /**

--- a/src/main/java/mekanism/common/base/IAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/base/IAdvancedBoundingBlock.java
@@ -6,6 +6,7 @@ import ic2.api.energy.tile.IEnergySink;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.energy.IStrictEnergyAcceptor;
 import mekanism.api.energy.IStrictEnergyStorage;
+import mekanism.common.capabilities.IOffsetCapability;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.security.ISecurityTile;
@@ -24,7 +25,7 @@ import net.minecraftforge.fml.common.Optional.InterfaceList;
 })
 public interface IAdvancedBoundingBlock extends ICapabilityProvider, IBoundingBlock, ISidedInventory, IEnergySink,
       IStrictEnergyAcceptor, IStrictEnergyStorage, IEnergyReceiver, IEnergyProvider, IComputerIntegration,
-      ISpecialConfigData, ISecurityTile {
+      ISpecialConfigData, ISecurityTile, IOffsetCapability {
 
     int[] getBoundSlots(BlockPos location, EnumFacing side);
 

--- a/src/main/java/mekanism/common/base/IFactory.java
+++ b/src/main/java/mekanism/common/base/IFactory.java
@@ -183,12 +183,8 @@ public interface IFactory {
             return false;
         }
 
-        public boolean canTubeConnect(EnumFacing side) {
-            if (fuelType == MachineFuelType.ADVANCED) {
-                return getTile().canTubeConnect(side);
-            }
-
-            return false;
+        public boolean supportsGas() {
+            return fuelType == MachineFuelType.ADVANCED;
         }
 
         public boolean isValidGas(Gas gas) {

--- a/src/main/java/mekanism/common/capabilities/Capabilities.java
+++ b/src/main/java/mekanism/common/capabilities/Capabilities.java
@@ -54,6 +54,9 @@ public class Capabilities {
     @CapabilityInject(IAlloyInteraction.class)
     public static Capability<IAlloyInteraction> ALLOY_INTERACTION_CAPABILITY = null;
 
+    //Kept in for compatibility with any mods that may try to reference it.
+    // However, nothing in Mekanism uses this anymore
+    @Deprecated
     @CapabilityInject(ITubeConnection.class)
     public static Capability<ITubeConnection> TUBE_CONNECTION_CAPABILITY = null;
 

--- a/src/main/java/mekanism/common/capabilities/DefaultTubeConnection.java
+++ b/src/main/java/mekanism/common/capabilities/DefaultTubeConnection.java
@@ -5,6 +5,7 @@ import mekanism.common.capabilities.DefaultStorageHelper.NullStorage;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 
+@Deprecated
 public class DefaultTubeConnection implements ITubeConnection {
 
     public static void register() {

--- a/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
@@ -5,7 +5,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.Vec3i;
 import net.minecraftforge.common.capabilities.Capability;
 
-public interface IOffsetCapability {
+public interface IOffsetCapability extends IToggleableCapability {
 
     boolean hasOffsetCapability(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset);
 

--- a/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
@@ -1,0 +1,17 @@
+package mekanism.common.capabilities;
+
+import javax.annotation.Nonnull;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.Vec3i;
+import net.minecraftforge.common.capabilities.Capability;
+
+public interface IOffsetCapability {
+
+    boolean hasOffsetCapability(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset);
+
+    <T> T getOffsetCapability(@Nonnull Capability<T> capability, EnumFacing side, Vec3i offset);
+
+    default boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset) {
+        return false;
+    }
+}

--- a/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IOffsetCapability.java
@@ -1,17 +1,63 @@
 package mekanism.common.capabilities;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.Vec3i;
 import net.minecraftforge.common.capabilities.Capability;
 
+/**
+ * Allows for handling capabilities at an offset to the actual implementer. This allows Tile Entities such as the
+ * Digital Miner to via the advanced bounding blocks be able to return a partial true for hasCapability for a given
+ * side. Example: Instead of the entire back side having access to the ItemHandler capability, only the eject slot on
+ * the back has access.
+ */
 public interface IOffsetCapability extends IToggleableCapability {
 
-    boolean hasOffsetCapability(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset);
+    /**
+     * Determines if this object has support for the capability in question on the specific side, with a given offset.
+     * The return value of this MIGHT change during runtime if this object gains or loses support for a capability. It
+     * is not required to call this function before calling {@link #getCapability(Capability, EnumFacing)}.
+     *
+     * @param capability The capability to check
+     * @param side The Side to check from: CAN BE NULL. Null is defined to represent 'internal' or 'self'
+     * @param offset An offset position to figure out what block is actually the one that is being checked.
+     * @return True if this object supports the capability. If true, then {@link #getCapability(Capability, EnumFacing)}
+     * must not return null.
+     */
+    boolean hasOffsetCapability(@Nonnull Capability<?> capability, @Nullable EnumFacing side, @Nonnull Vec3i offset);
 
-    <T> T getOffsetCapability(@Nonnull Capability<T> capability, EnumFacing side, Vec3i offset);
+    /**
+     * Retrieves the handler for the capability requested on the specific side with a given offset.
+     * <ul>
+     * <li>The return value <strong>CAN</strong> be null if the object does not support the capability.</il>
+     * <li>The return value <strong>MUST</strong> be null if {@link #isOffsetCapabilityDisabled(Capability, EnumFacing,
+     * Vec3i)} is true.</il>
+     * <li>The return value <strong>CAN</strong> be the same for multiple faces.</li>
+     * </ul>
+     *
+     * @param capability The capability to check
+     * @param side The Side to check from,
+     * <strong>CAN BE NULL</strong>. Null is defined to represent 'internal' or 'self'
+     * @param offset An offset position to figure out what block is actually the one that is being checked.
+     * @return The requested capability. Must <strong>NOT</strong> be null when {@link #hasCapability(Capability,
+     * EnumFacing)} would return true.
+     */
+    @Nullable
+    <T> T getOffsetCapability(@Nonnull Capability<T> capability, @Nullable EnumFacing side, @Nonnull Vec3i offset);
 
-    default boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset) {
+    /**
+     * Checks if a given capability is disabled for this provider on the given side and offset. If false is returned it
+     * makes makes no guarantees that the capability is provided.
+     *
+     * @param capability The capability to check
+     * @param side The Side to check from: CAN BE NULL. Null is defined to represent 'internal' or 'self'
+     * @param offset An offset position to figure out what block is actually the one that is being checked.
+     * @return True if this given capability is disabled for the given side and offset. If true, then {@link
+     * #hasOffsetCapability(Capability, EnumFacing, Vec3i)} should return false.
+     */
+    default boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, @Nullable EnumFacing side,
+          @Nonnull Vec3i offset) {
         return false;
     }
 }

--- a/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
@@ -1,13 +1,27 @@
 package mekanism.common.capabilities;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
+/**
+ * A capability provider that allows for easier toggling of capabilities in subclasses where everything else may be the
+ * same but the capability may not always be enabled.
+ */
 public interface IToggleableCapability extends ICapabilityProvider {
 
-    default boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+    /**
+     * Checks if a given capability is disabled for this provider on the given side. If false is returned it makes makes
+     * no guarantees that the capability is provided.
+     *
+     * @param capability The capability to check
+     * @param side The Side to check from: CAN BE NULL. Null is defined to represent 'internal' or 'self'
+     * @return True if this given capability is disabled for the given side. If true, then {@link
+     * #hasCapability(Capability, EnumFacing)} should return false.
+     */
+    default boolean isCapabilityDisabled(@Nonnull Capability<?> capability, @Nullable EnumFacing side) {
         return false;
     }
 }

--- a/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
@@ -3,8 +3,9 @@ package mekanism.common.capabilities;
 import javax.annotation.Nonnull;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 
-public interface IToggleableCapability {
+public interface IToggleableCapability extends ICapabilityProvider {
 
     default boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
         return false;

--- a/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
+++ b/src/main/java/mekanism/common/capabilities/IToggleableCapability.java
@@ -1,0 +1,12 @@
+package mekanism.common.capabilities;
+
+import javax.annotation.Nonnull;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+
+public interface IToggleableCapability {
+
+    default boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return false;
+    }
+}

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
@@ -431,7 +431,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
             return super.hasCapability(capability, facing);
         }
 
-        return inv.hasCapability(capability, facing);
+        return inv.hasOffsetCapability(capability, facing, pos.subtract(mainPos));
     }
 
     @Override
@@ -445,6 +445,6 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
             return super.getCapability(capability, facing);
         }
 
-        return inv.getCapability(capability, facing);
+        return inv.getOffsetCapability(capability, facing, pos.subtract(mainPos));
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
@@ -9,7 +9,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
-import mekanism.api.gas.ITubeConnection;
+import mekanism.common.capabilities.Capabilities;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.IntegerInput;
 import mekanism.common.recipe.machines.AmbientGasRecipe;
@@ -19,9 +19,10 @@ import mekanism.common.util.TileUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-public class TileEntityAmbientAccumulator extends TileEntityContainerBlock implements IGasHandler, ITubeConnection {
+public class TileEntityAmbientAccumulator extends TileEntityContainerBlock implements IGasHandler {
 
     public static Random gasRand = new Random();
     public GasTank collectedGas = new GasTank(1000);
@@ -76,11 +77,6 @@ public class TileEntityAmbientAccumulator extends TileEntityContainerBlock imple
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return true;
-    }
-
-    @Override
     public TileNetworkList getNetworkedData(TileNetworkList data) {
         TileUtils.addTankData(data, collectedGas);
         return data;
@@ -97,5 +93,20 @@ public class TileEntityAmbientAccumulator extends TileEntityContainerBlock imple
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    //Gas capability is never disabled here
+    @Override
+    public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        return capability == Capabilities.GAS_HANDLER_CAPABILITY || super.hasCapability(capability, side);
+    }
+
+    @Override
+    public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
+            return (T) this;
+        }
+
+        return super.getCapability(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAmbientAccumulator.java
@@ -104,7 +104,7 @@ public class TileEntityAmbientAccumulator extends TileEntityContainerBlock imple
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -14,7 +14,6 @@ import mekanism.common.base.IActiveState;
 import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.base.ITierUpgradeable;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.capabilities.IToggleableCapability;
 import mekanism.common.content.transporter.TransitRequest;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.item.ItemBlockBasic;
@@ -44,7 +43,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
 public class TileEntityBin extends TileEntityBasicBlock implements ISidedInventory, IActiveState, IConfigurable,
-      ITierUpgradeable, IToggleableCapability {
+      ITierUpgradeable {
 
     private static final int[] UPSLOTS = {1};
     private static final int[] DOWNSLOTS = {0};
@@ -614,32 +613,19 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
-        if (isCapabilityDisabled(capability, side)) {
-            return false;
-        }
         return capability == Capabilities.CONFIGURABLE_CAPABILITY
               || capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
-        if (isCapabilityDisabled(capability, side)) {
-            return null;
-        } else if (capability == Capabilities.CONFIGURABLE_CAPABILITY) {
+        if (capability == Capabilities.CONFIGURABLE_CAPABILITY) {
             return Capabilities.CONFIGURABLE_CAPABILITY.cast(this);
         } else if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(myItemHandler);
         }
 
         return super.getCapability(capability, side);
-    }
-
-    @Override
-    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return side != EnumFacing.UP && side != EnumFacing.DOWN;
-        }
-        return false;
     }
 
     private class BinItemHandler implements IItemHandler {

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -664,6 +664,11 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
             return 1;
         }
 
+        @Override
+        public boolean isItemValid(int slot, @Nonnull ItemStack stack) {
+            return slot == 0;
+        }
+
         @Nonnull
         @Override
         public ItemStack getStackInSlot(int slot) {

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
@@ -29,6 +29,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoilerData> implements IHeatTransfer {
 
@@ -353,6 +354,14 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     @Nonnull

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
@@ -342,6 +342,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
         return null;
     }
 
+    //TODO: Decide if heat capability should be moved to valve only
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
         return capability == Capabilities.HEAT_TRANSFER_CAPABILITY || super.hasCapability(capability, side);
@@ -350,7 +351,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
@@ -182,7 +182,7 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing implements IFl
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
             if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-                return (T) new FluidHandlerWrapper(this, side);
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
             }
         }
 

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -124,7 +124,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
         if (capability == Capabilities.TILE_NETWORK_CAPABILITY) {
-            return (T) this;
+            return Capabilities.TILE_NETWORK_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, facing);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
@@ -16,7 +17,6 @@ import mekanism.common.SideData;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.usage;
@@ -26,6 +26,7 @@ import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.prefab.TileEntityOperationalMachine;
+import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.ItemDataUtils;
@@ -213,6 +214,9 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
               || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.CONFIG_CARD_CAPABILITY || super.hasCapability(capability, side);
@@ -220,12 +224,21 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -11,7 +11,6 @@ import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.SideData;
 import mekanism.common.base.ISideConfiguration;
@@ -39,7 +38,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine implements IGasHandler,
-      ITubeConnection, ISideConfiguration, ISustainedData, ITankManager, IConfigCardAccess {
+      ISideConfiguration, ISustainedData, ITankManager, IConfigCardAccess {
 
     public static final int MAX_GAS = 10000;
 
@@ -176,11 +175,6 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return configComponent.getOutput(TransmissionType.GAS, side, facing).hasSlot(0);
-    }
-
-    @Override
     public boolean canReceiveGas(EnumFacing side, Gas type) {
         return configComponent.getOutput(TransmissionType.GAS, side, facing).hasSlot(0) && inputTank.canReceive(type) &&
               RecipeHandler.Recipe.CHEMICAL_CRYSTALLIZER.containsRecipe(type);
@@ -217,7 +211,6 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
             return false;
         }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.CONFIG_CARD_CAPABILITY || super.hasCapability(capability, side);
     }
 
@@ -226,8 +219,7 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
         if (isCapabilityDisabled(capability, side)) {
             return null;
         }
-        if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
-              || capability == Capabilities.CONFIG_CARD_CAPABILITY) {
+        if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -26,7 +26,6 @@ import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.prefab.TileEntityOperationalMachine;
-import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.ItemDataUtils;
@@ -237,7 +236,7 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
@@ -277,7 +277,7 @@ public class TileEntityChemicalDissolutionChamber extends TileEntityMachine impl
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
@@ -238,7 +238,7 @@ public class TileEntityChemicalInfuser extends TileEntityMachine implements IGas
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
@@ -69,11 +69,6 @@ public class TileEntityChemicalInjectionChamber extends TileEntityAdvancedElectr
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return configComponent.getOutput(TransmissionType.GAS, side, facing).hasSlot(0);
-    }
-
-    @Override
     public boolean isValidGas(Gas gas) {
         return Recipe.CHEMICAL_INJECTION_CHAMBER.containsRecipe(gas);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
@@ -191,7 +191,7 @@ public class TileEntityChemicalOxidizer extends TileEntityOperationalMachine imp
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -289,9 +289,9 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -298,7 +298,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                         response = InventoryUtils.putStackInInventory(ejectInv, ejectMap, facing.getOpposite(), false);
                     }
                     if (!response.isEmpty()) {
-                        response.getInvStack(this, facing.getOpposite()).use();
+                        response.getInvStack(ejectTile, facing.getOpposite()).use();
                     }
 
                     delayTicks = 10;

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -1314,7 +1314,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public boolean hasOffsetCapability(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset) {
+    public boolean hasOffsetCapability(@Nonnull Capability<?> capability, EnumFacing side, @Nonnull Vec3i offset) {
         if (isOffsetCapabilityDisabled(capability, side, offset)) {
             return false;
         }
@@ -1327,7 +1327,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public <T> T getOffsetCapability(@Nonnull Capability<T> capability, EnumFacing side, Vec3i offset) {
+    public <T> T getOffsetCapability(@Nonnull Capability<T> capability, EnumFacing side, @Nonnull Vec3i offset) {
         if (isOffsetCapabilityDisabled(capability, side, offset)) {
             return null;
         } else if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
@@ -1343,7 +1343,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side, Vec3i offset) {
+    public boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side,
+          @Nonnull Vec3i offset) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             //Input
             if (offset.equals(new Vec3i(0, 1, 0))) {

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -1359,6 +1359,10 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
             return true;
         }
         if (isStrictEnergy(capability) || capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
+            if (offset.equals(Vec3i.NULL_VECTOR)) {
+                //Disable if it is the bottom port but wrong side of it
+                return side != EnumFacing.DOWN;
+            }
             EnumFacing left = MekanismUtils.getLeft(facing);
             EnumFacing right = MekanismUtils.getRight(facing);
             if (offset.equals(new Vec3i(left.getXOffset(), 0, left.getZOffset()))) {

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
@@ -25,7 +25,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTankData> implements
       IFluidContainerManager {
@@ -264,5 +266,13 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFluidHandlerWrapper {
 
@@ -97,6 +98,14 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     @Nonnull

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -93,7 +93,7 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
             if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-                return (T) new FluidHandlerWrapper(this, side);
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
             }
         }
 

--- a/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
@@ -468,11 +468,11 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.CONFIGURABLE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIGURABLE_CAPABILITY.cast(this);
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -489,9 +489,9 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -314,6 +314,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        //Special isCapabilityDisabled override not needed here as it already gets handled in TileEntityElectricBlock
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -316,7 +316,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         //Special isCapabilityDisabled override not needed here as it already gets handled in TileEntityElectricBlock
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIG_CARD_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -49,7 +49,6 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.tile.prefab.TileEntityMachine;
-import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.GasUtils;
 import mekanism.common.util.InventoryUtils;
@@ -406,7 +405,8 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
                         continue;
                     }
 
-                    Pair<ItemStack, ItemStack> evened = StackUtils.even(inventory.get(invID1.ID), inventory.get(invID2.ID));
+                    Pair<ItemStack, ItemStack> evened = StackUtils
+                          .even(inventory.get(invID1.ID), inventory.get(invID2.ID));
                     inventory.set(invID1.ID, evened.getLeft());
                     inventory.set(invID2.ID, evened.getRight());
 
@@ -927,7 +927,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -8,6 +8,7 @@ import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
@@ -32,7 +33,6 @@ import mekanism.common.base.IFactory.RecipeType;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITierUpgradeable;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
@@ -49,6 +49,7 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.tile.prefab.TileEntityMachine;
+import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.GasUtils;
 import mekanism.common.util.InventoryUtils;
@@ -900,6 +901,9 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
               || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.CONFIG_CARD_CAPABILITY
@@ -909,6 +913,9 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.CONFIG_CARD_CAPABILITY
               || capability == Capabilities.SPECIAL_CONFIG_DATA_CAPABILITY) {
@@ -916,6 +923,12 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -430,11 +430,11 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.CONFIGURABLE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIGURABLE_CAPABILITY.cast(this);
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -427,11 +427,11 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.CONFIGURABLE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIGURABLE_CAPABILITY.cast(this);
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -24,7 +24,6 @@ import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.component.TileComponentUpgrade;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
-import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
@@ -705,7 +704,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -696,7 +696,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
             return null;
         }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIG_CARD_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
+import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.PacketHandler;
 import mekanism.common.SideData;
@@ -12,7 +13,6 @@ import mekanism.common.Upgrade;
 import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.IUpgradeTile;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.usage;
@@ -24,6 +24,7 @@ import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.component.TileComponentUpgrade;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
+import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
@@ -684,15 +685,27 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.CONFIG_CARD_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
@@ -275,7 +275,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -266,7 +266,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -12,7 +12,6 @@ import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.SideData;
@@ -29,7 +28,6 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
-import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.GasUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
@@ -45,8 +43,8 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-public class TileEntityGasTank extends TileEntityContainerBlock implements IGasHandler, ITubeConnection,
-      IRedstoneControl, ISideConfiguration, ISecurityTile, ITierUpgradeable, IComputerIntegration {
+public class TileEntityGasTank extends TileEntityContainerBlock implements IGasHandler, IRedstoneControl,
+      ISideConfiguration, ISecurityTile, ITierUpgradeable, IComputerIntegration {
 
     private static final String[] methods = new String[]{"getMaxGas", "getStoredGas", "getGas"};
     /**
@@ -246,18 +244,14 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
         if (isCapabilityDisabled(capability, side)) {
             return false;
         }
-        return capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
-              || super.hasCapability(capability, side);
+        return capability == Capabilities.GAS_HANDLER_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (isCapabilityDisabled(capability, side)) {
             return null;
-        }
-        if (capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY) {
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
             return (T) this;
         }
 
@@ -347,11 +341,6 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
     @Override
     public boolean canSetFacing(int side) {
         return side != 0 && side != 1;
-    }
-
-    @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return true;
     }
 
     public int getRedstoneLevel() {

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -252,7 +252,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
@@ -20,7 +21,6 @@ import mekanism.common.Tier.GasTankTier;
 import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ITierUpgradeable;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
@@ -29,6 +29,7 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
+import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.GasUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
@@ -242,6 +243,9 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
               || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || super.hasCapability(capability, side);
@@ -249,12 +253,21 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY
               || capability == Capabilities.TUBE_CONNECTION_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityGlowPanel.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGlowPanel.java
@@ -104,7 +104,7 @@ public class TileEntityGlowPanel extends TileEntity implements ITileNetwork {
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
         if (capability == Capabilities.TILE_NETWORK_CAPABILITY) {
-            return (T) this;
+            return Capabilities.TILE_NETWORK_CAPABILITY.cast(this);
         }
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
@@ -210,7 +210,7 @@ public class TileEntityInductionCasing extends TileEntityMultiblock<Synchronized
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, net.minecraft.util.EnumFacing facing) {
         if (capability == Capabilities.ENERGY_STORAGE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.ENERGY_STORAGE_CAPABILITY.cast(this);
         }
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
@@ -25,6 +25,7 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityInductionCasing extends TileEntityMultiblock<SynchronizedMatrixData> implements
       IStrictEnergyStorage, IComputerIntegration {
@@ -218,5 +219,13 @@ public class TileEntityInductionCasing extends TileEntityMultiblock<Synchronized
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCell.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCell.java
@@ -99,7 +99,7 @@ public class TileEntityInductionCell extends TileEntityBasicBlock implements ISt
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, net.minecraft.util.EnumFacing facing) {
         if (capability == Capabilities.ENERGY_STORAGE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.ENERGY_STORAGE_CAPABILITY.cast(this);
         }
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -44,6 +44,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Optional.Interface;
 import net.minecraftforge.fml.common.Optional.InterfaceList;
 import net.minecraftforge.fml.common.Optional.Method;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 @InterfaceList({
       @Interface(iface = "ic2.api.energy.tile.IEnergySink", modid = MekanismHooks.IC2_MOD_ID),
@@ -494,5 +495,13 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             return ChargeUtils.canBeDischarged(stack);
         }
         return false;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return false;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -473,7 +473,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
         }
 
         if (capability == CapabilityEnergy.ENERGY) {
-            return (T) forgeEnergyManager.getWrapper(this, facing);
+            return CapabilityEnergy.ENERGY.cast(forgeEnergyManager.getWrapper(this, facing));
         }
 
         return super.getCapability(capability, facing);

--- a/src/main/java/mekanism/common/tile/TileEntityLaser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaser.java
@@ -15,6 +15,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityLaser extends TileEntityEffectsBlock {
 
@@ -110,5 +112,13 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
@@ -355,13 +355,13 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
         if (capability == Capabilities.ENERGY_STORAGE_CAPABILITY) {
-            return (T) this;
+            return Capabilities.ENERGY_STORAGE_CAPABILITY.cast(this);
         }
         if (capability == Capabilities.ENERGY_OUTPUTTER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.ENERGY_OUTPUTTER_CAPABILITY.cast(this);
         }
         if (capability == Capabilities.LASER_RECEPTOR_CAPABILITY) {
-            return (T) this;
+            return Capabilities.LASER_RECEPTOR_CAPABILITY.cast(this);
         }
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
@@ -31,6 +31,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityLaserAmplifier extends TileEntityContainerBlock implements ILaserReceptor, IRedstoneControl,
       IStrictEnergyOutputter, IStrictEnergyStorage, IComputerIntegration, ISecurityTile {
@@ -369,6 +370,14 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     public enum RedstoneOutput {

--- a/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
@@ -220,7 +220,7 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.LASER_RECEPTOR_CAPABILITY) {
-            return (T) this;
+            return Capabilities.LASER_RECEPTOR_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -31,7 +31,6 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityOperationalMachine;
-import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
@@ -370,7 +369,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
             return null;
         }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIG_CARD_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -378,7 +378,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -31,6 +31,7 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityOperationalMachine;
+import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
@@ -357,16 +358,28 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.CONFIG_CARD_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
@@ -40,9 +40,4 @@ public class TileEntityOsmiumCompressor extends TileEntityAdvancedElectricMachin
     public boolean canReceiveGas(EnumFacing side, Gas type) {
         return gasTank.canReceive(type) && isValidGas(type);
     }
-
-    @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return true;
-    }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -370,9 +370,9 @@ public class TileEntityPRC extends
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
@@ -55,11 +55,6 @@ public class TileEntityPurificationChamber extends TileEntityAdvancedElectricMac
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return true;
-    }
-
-    @Override
     public boolean isValidGas(Gas gas) {
         return Recipe.PURIFICATION_CHAMBER.containsRecipe(gas);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -632,7 +632,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -648,7 +648,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -619,6 +619,9 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
               || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.HEAT_TRANSFER_CAPABILITY
@@ -628,6 +631,9 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
             return (T) this;
@@ -638,6 +644,12 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -254,7 +254,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -268,9 +268,9 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntitySecurityDesk.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySecurityDesk.java
@@ -25,9 +25,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntitySecurityDesk extends TileEntityContainerBlock implements IBoundingBlock {
 
@@ -282,5 +284,14 @@ public class TileEntitySecurityDesk extends TileEntityContainerBlock implements 
         // accessible by automation, as then people could lock items to other
         // people unintentionally
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            //For the same reason as the getSlotsForFace does not give any slots, don't expose this here
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -257,7 +257,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationBlock.java
@@ -12,6 +12,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityThermalEvaporationBlock extends TileEntityContainerBlock implements IComputerIntegration {
 
@@ -132,6 +134,14 @@ public class TileEntityThermalEvaporationBlock extends TileEntityContainerBlock 
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     public class ControllerFinder {

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -32,6 +32,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
@@ -39,6 +40,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityThermalEvaporationController extends TileEntityThermalEvaporationBlock implements IActiveState,
       ITankManager {
@@ -609,7 +611,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
         return new Object[]{inputTank, outputTank};
     }
 
-    //TODO: Move getSlotsForFace and isItemValidForSlot to Valve
+    //TODO: Move getSlotsForFace, isItemValidForSlot, and isCapabilityDisabled to Valve
     //NOTE: For now it has to be in the controller as it uses the old multiblock structure so the valve's don't actually
     //have an inventory, which causes a crash trying to insert into them
     @Nonnull
@@ -626,5 +628,13 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
             return FluidContainerUtils.isFluidContainer(stack) && FluidUtil.getFluidContained(stack) == null;
         }
         return false;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return false;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
@@ -150,11 +150,11 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY && getController() != null) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -6,17 +6,22 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import mekanism.api.EnumColor;
+import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.SideData;
 import mekanism.common.SideData.IOState;
 import mekanism.common.base.ITileComponent;
-import mekanism.api.TileNetworkList;
+import mekanism.common.capabilities.Capabilities;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileComponentConfig implements ITileComponent {
 
@@ -76,6 +81,24 @@ public class TileComponentConfig implements ITileComponent {
         }
         EnumFacing[] translatedFacings = MekanismUtils.getBaseOrientations(facing);
         return getConfig(type).get(translatedFacings[sideToTest.ordinal()]) == dataIndex;
+    }
+
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side, EnumFacing tileDirection) {
+        TransmissionType type = null;
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            type = TransmissionType.ITEM;
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
+            type = TransmissionType.GAS;
+        } else if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
+            type = TransmissionType.HEAT;
+        } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            type = TransmissionType.FLUID;
+        }
+        //Energy is handled by the TileEntityElectricBlock anyways in the super clauses so no need to bother with it
+        if (type != null) {
+            return supports(type) && hasSideForData(type, tileDirection, 0, side);
+        }
+        return false;
     }
 
     public void setCanEject(TransmissionType type, boolean eject) {

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -3,18 +3,17 @@ package mekanism.common.tile.prefab;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.EnumColor;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismItems;
 import mekanism.common.SideData;
 import mekanism.common.Upgrade;
 import mekanism.common.base.ISustainedData;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
@@ -39,7 +38,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends
       TileEntityUpgradeableMachine<AdvancedMachineInput, ItemStackOutput, RECIPE> implements IGasHandler,
-      ITubeConnection, ISustainedData {
+      ISustainedData {
 
     private static final String[] methods = new String[]{"getEnergy", "getSecondaryStored", "getProgress", "isActive",
           "facing", "canOperate", "getMaxEnergy", "getEnergyNeeded"};
@@ -306,11 +305,6 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return false;
-    }
-
-    @Override
     public int receiveGas(EnumFacing side, GasStack stack, boolean doTransfer) {
         return 0;
     }
@@ -338,15 +332,17 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
-        return capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
-              || super.hasCapability(capability, side);
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
+        return capability == Capabilities.GAS_HANDLER_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
-        if (capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
             return (T) this;
         }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -343,7 +343,7 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -204,7 +204,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing facing) {
         if (capability == Capabilities.TILE_NETWORK_CAPABILITY) {
-            return (T) this;
+            return Capabilities.TILE_NETWORK_CAPABILITY.cast(this);
         }
         return super.getCapability(capability, facing);
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -12,6 +12,7 @@ import mekanism.common.recipe.machines.MachineRecipe;
 import mekanism.common.recipe.outputs.MachineOutput;
 import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
+import mekanism.common.util.CapabilityUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
@@ -71,15 +72,27 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.CONFIG_CARD_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+              .isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -12,7 +12,6 @@ import mekanism.common.recipe.machines.MachineRecipe;
 import mekanism.common.recipe.outputs.MachineOutput;
 import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
-import mekanism.common.util.CapabilityUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
@@ -84,7 +83,7 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
             return null;
         }
         if (capability == Capabilities.CONFIG_CARD_CAPABILITY) {
-            return (T) this;
+            return Capabilities.CONFIG_CARD_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -92,7 +92,7 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
 
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        return CapabilityUtils.isCapabilityDisabled(capability, side, this) || super
+        return configComponent.isCapabilityDisabled(capability, side, facing) || super
               .isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
@@ -375,10 +375,11 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
-        if (isStrictEnergy(capability) || capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
-            return !isCapabilityDisabled(capability, side);
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
         }
-        return super.hasCapability(capability, side);
+        return isStrictEnergy(capability) || capability == CapabilityEnergy.ENERGY || isTesla(capability, side) || super
+              .hasCapability(capability, side);
     }
 
     @Override
@@ -395,13 +396,13 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
         return super.getCapability(capability, side);
     }
 
-    protected  <T> boolean isStrictEnergy(@Nonnull Capability<T> capability) {
+    protected boolean isStrictEnergy(@Nonnull Capability capability) {
         return capability == Capabilities.ENERGY_STORAGE_CAPABILITY
               || capability == Capabilities.ENERGY_ACCEPTOR_CAPABILITY ||
               capability == Capabilities.ENERGY_OUTPUTTER_CAPABILITY;
     }
 
-    protected <T> boolean isTesla(@Nonnull Capability<T> capability, EnumFacing side) {
+    protected boolean isTesla(@Nonnull Capability capability, EnumFacing side) {
         return capability == Capabilities.TESLA_HOLDER_CAPABILITY
               || (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && sideIsConsumer(side))
               || (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(side));
@@ -413,5 +414,13 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 
     protected TeslaIntegration getTeslaEnergyWrapper(EnumFacing side) {
         return teslaManager.getWrapper(this, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isStrictEnergy(capability) || capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
+            return !sideIsConsumer(side) && !sideIsOutput(side);
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -457,7 +457,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY) {
-            return (T) getTransmitter();
+            return Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY.cast(getTransmitter());
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -302,7 +302,7 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) manager.getWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(manager.getWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -286,7 +286,7 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -218,7 +218,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -185,9 +185,9 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N>> e
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.GRID_TRANSMITTER_CAPABILITY) {
-            return (T) getTransmitter();
+            return Capabilities.GRID_TRANSMITTER_CAPABILITY.cast(getTransmitter());
         } else if (capability == Capabilities.ALLOY_INTERACTION_CAPABILITY) {
-            return (T) this;
+            return Capabilities.ALLOY_INTERACTION_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -50,9 +50,9 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
     public double lastWrite = 0;
 
     public EnergyStack buffer = new EnergyStack(0);
-    private CapabilityWrapperManager teslaManager = new CapabilityWrapperManager(getClass(),
+    private CapabilityWrapperManager teslaManager = new CapabilityWrapperManager<>(getClass(),
           TeslaCableIntegration.class);
-    private CapabilityWrapperManager forgeEnergyManager = new CapabilityWrapperManager(getClass(),
+    private CapabilityWrapperManager forgeEnergyManager = new CapabilityWrapperManager<>(getClass(),
           ForgeEnergyCableIntegration.class);
 
     @Override

--- a/src/main/java/mekanism/common/util/CapabilityUtils.java
+++ b/src/main/java/mekanism/common/util/CapabilityUtils.java
@@ -1,8 +1,16 @@
 package mekanism.common.util;
 
+import javax.annotation.Nonnull;
+import mekanism.api.transmitters.TransmissionType;
+import mekanism.common.base.ISideConfiguration;
+import mekanism.common.capabilities.Capabilities;
+import mekanism.common.tile.component.TileComponentConfig;
+import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public final class CapabilityUtils {
 
@@ -20,5 +28,25 @@ public final class CapabilityUtils {
         }
 
         return provider.getCapability(cap, side);
+    }
+
+    public static <T extends TileEntityContainerBlock & ISideConfiguration> boolean isCapabilityDisabled(
+          @Nonnull Capability<?> capability, EnumFacing side, T tile) {
+        TransmissionType type = null;
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            type = TransmissionType.ITEM;
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
+            type = TransmissionType.GAS;
+        } else if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
+            type = TransmissionType.HEAT;
+        } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            type = TransmissionType.FLUID;
+        }
+        //Energy is handled by the TileEntityElectricBlock anyways in the super clauses so no need to bother with it
+        if (type != null) {
+            TileComponentConfig config = tile.getConfig();
+            return config != null && config.supports(type) && config.hasSideForData(type, tile.facing, 0, side);
+        }
+        return false;
     }
 }

--- a/src/main/java/mekanism/common/util/CapabilityUtils.java
+++ b/src/main/java/mekanism/common/util/CapabilityUtils.java
@@ -1,16 +1,8 @@
 package mekanism.common.util;
 
-import javax.annotation.Nonnull;
-import mekanism.api.transmitters.TransmissionType;
-import mekanism.common.base.ISideConfiguration;
-import mekanism.common.capabilities.Capabilities;
-import mekanism.common.tile.component.TileComponentConfig;
-import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
-import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
-import net.minecraftforge.items.CapabilityItemHandler;
 
 public final class CapabilityUtils {
 
@@ -28,25 +20,5 @@ public final class CapabilityUtils {
         }
 
         return provider.getCapability(cap, side);
-    }
-
-    public static <T extends TileEntityContainerBlock & ISideConfiguration> boolean isCapabilityDisabled(
-          @Nonnull Capability<?> capability, EnumFacing side, T tile) {
-        TransmissionType type = null;
-        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            type = TransmissionType.ITEM;
-        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            type = TransmissionType.GAS;
-        } else if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            type = TransmissionType.HEAT;
-        } else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            type = TransmissionType.FLUID;
-        }
-        //Energy is handled by the TileEntityElectricBlock anyways in the super clauses so no need to bother with it
-        if (type != null) {
-            TileComponentConfig config = tile.getConfig();
-            return config != null && config.supports(type) && config.hasSideForData(type, tile.facing, 0, side);
-        }
-        return false;
     }
 }

--- a/src/main/java/mekanism/common/util/GasUtils.java
+++ b/src/main/java/mekanism/common/util/GasUtils.java
@@ -11,7 +11,6 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.common.MekanismFluids;
 import mekanism.common.OreDictCache;
 import mekanism.common.Tier.GasTankTier;
@@ -71,14 +70,7 @@ public final class GasUtils {
             return false;
         }
 
-        if (CapabilityUtils.hasCapability(tile, Capabilities.TUBE_CONNECTION_CAPABILITY, side.getOpposite())) {
-            ITubeConnection connection = CapabilityUtils
-                  .getCapability(tile, Capabilities.TUBE_CONNECTION_CAPABILITY, side.getOpposite());
-
-            return connection.canTubeConnect(side.getOpposite());
-        }
-
-        return false;
+        return CapabilityUtils.hasCapability(tile, Capabilities.GAS_HANDLER_CAPABILITY, side.getOpposite());
     }
 
     /**

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -10,7 +10,6 @@ import mekanism.common.content.transporter.TransitRequest;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.content.transporter.TransporterStack;
-import mekanism.common.tile.TileEntityBin;
 import mekanism.common.tile.TileEntityLogisticalSorter;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.tileentity.TileEntity;
@@ -26,14 +25,6 @@ public final class TransporterUtils {
     public static boolean isValidAcceptorOnSide(TileEntity tile, EnumFacing side) {
         if (CapabilityUtils.hasCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite())) {
             return false;
-        }
-        if (tile instanceof TileEntityBin) {
-            //Special handling to allow bins to only be connected to from the top and bottom by logistical transporters
-            //TODO: Strip this out when making the capability pass and only actually give the capabilities from the top
-            // and bottom. For the bottom one maybe even only give it "read only" access.
-            if (side != EnumFacing.DOWN && side != EnumFacing.UP) {
-                return false;
-            }
         }
         return InventoryUtils.isItemHandler(tile, side.getOpposite());
     }

--- a/src/main/java/mekanism/generators/common/tile/TileEntityAdvancedSolarGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityAdvancedSolarGenerator.java
@@ -61,7 +61,7 @@ public class TileEntityAdvancedSolarGenerator extends TileEntitySolarGenerator i
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.EVAPORATION_SOLAR_CAPABILITY) {
-            return (T) this;
+            return Capabilities.EVAPORATION_SOLAR_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
@@ -272,7 +272,7 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IFlui
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (side != facing && capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -309,7 +309,7 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
         if (isCapabilityDisabled(capability, side)) {
             return null;
         } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.GAS_HANDLER_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -2,17 +2,16 @@ package mekanism.generators.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
+import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
 import mekanism.api.gas.IGasItem;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.common.FuelHandler;
 import mekanism.common.FuelHandler.FuelGas;
 import mekanism.common.base.ISustainedData;
-import mekanism.api.TileNetworkList;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig.general;
 import mekanism.common.util.ChargeUtils;
@@ -27,8 +26,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-public class TileEntityGasGenerator extends TileEntityGenerator implements IGasHandler, ITubeConnection,
-      ISustainedData {
+public class TileEntityGasGenerator extends TileEntityGenerator implements IGasHandler, ISustainedData {
 
     private static final String[] methods = new String[]{"getEnergy", "getOutput", "getMaxEnergy", "getEnergyNeeded",
           "getGas", "getGasNeeded"};
@@ -299,25 +297,30 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return side != facing;
-    }
-
-    @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
-        return capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
-              || super.hasCapability(capability, side);
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
+        return capability == Capabilities.GAS_HANDLER_CAPABILITY || super.hasCapability(capability, side);
     }
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
-        if (capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY) {
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
             return (T) this;
         }
 
         return super.getCapability(capability, side);
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
+            return side == facing;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
@@ -387,11 +387,11 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.HEAT_TRANSFER_CAPABILITY) {
-            return (T) this;
+            return Capabilities.HEAT_TRANSFER_CAPABILITY.cast(this);
         }
 
         if (side != facing && capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
@@ -2,12 +2,16 @@ package mekanism.generators.common.tile.reactor;
 
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
 import mekanism.generators.common.FusionReactor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public abstract class TileEntityReactorBlock extends TileEntityElectricBlock {
 
@@ -104,6 +108,16 @@ public abstract class TileEntityReactorBlock extends TileEntityElectricBlock {
                 found.formMultiblock(false);
             }
         }
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        } else if (isStrictEnergy(capability)|| capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     public class ControllerFinder {

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
@@ -10,7 +10,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.items.CapabilityItemHandler;
 
 public abstract class TileEntityReactorBlock extends TileEntityElectricBlock {
@@ -113,8 +112,6 @@ public abstract class TileEntityReactorBlock extends TileEntityElectricBlock {
     @Override
     public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-            return true;
-        } else if (isStrictEnergy(capability)|| capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
             return true;
         }
         return super.isCapabilityDisabled(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
+import mekanism.common.util.InventoryUtils;
 import mekanism.generators.common.FusionReactor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
@@ -107,6 +108,12 @@ public abstract class TileEntityReactorBlock extends TileEntityElectricBlock {
                 found.formMultiblock(false);
             }
         }
+    }
+
+    @Nonnull
+    @Override
+    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
+        return InventoryUtils.EMPTY;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -341,6 +341,7 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
             //Allow inserting
             return false;
         }
+        //TODO: Decide if we want the port to be able to accept Hohlraum as well as the controller
         return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -341,7 +341,6 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
             //Allow inserting
             return false;
         }
-        //TODO: Decide if we want the port to be able to accept Hohlraum as well as the controller
         return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -26,11 +26,13 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityReactorController extends TileEntityReactorBlock implements IActiveState {
 
@@ -331,5 +333,14 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
     @Override
     public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
         return stack.getItem() instanceof ItemHohlraum;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            //Allow inserting
+            return false;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorFrame.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorFrame.java
@@ -1,19 +1,9 @@
 package mekanism.generators.common.tile.reactor;
 
-import javax.annotation.Nonnull;
-import mekanism.common.util.InventoryUtils;
-import net.minecraft.util.EnumFacing;
-
 public class TileEntityReactorFrame extends TileEntityReactorBlock {
 
     @Override
     public boolean isFrame() {
         return true;
-    }
-
-    @Nonnull
-    @Override
-    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        return InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorGlass.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorGlass.java
@@ -1,19 +1,9 @@
 package mekanism.generators.common.tile.reactor;
 
-import javax.annotation.Nonnull;
-import mekanism.common.util.InventoryUtils;
-import net.minecraft.util.EnumFacing;
-
 public class TileEntityReactorGlass extends TileEntityReactorBlock {
 
     @Override
     public boolean isFrame() {
         return false;
-    }
-
-    @Nonnull
-    @Override
-    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        return InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLaserFocusMatrix.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLaserFocusMatrix.java
@@ -3,7 +3,6 @@ package mekanism.generators.common.tile.reactor;
 import javax.annotation.Nonnull;
 import mekanism.api.lasers.ILaserReceptor;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.util.InventoryUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 
@@ -38,11 +37,5 @@ public class TileEntityReactorLaserFocusMatrix extends TileEntityReactorBlock im
         }
 
         return super.getCapability(capability, side);
-    }
-
-    @Nonnull
-    @Override
-    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        return InventoryUtils.EMPTY;
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLaserFocusMatrix.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLaserFocusMatrix.java
@@ -33,7 +33,7 @@ public class TileEntityReactorLaserFocusMatrix extends TileEntityReactorBlock im
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if (capability == Capabilities.LASER_RECEPTOR_CAPABILITY) {
-            return (T) this;
+            return Capabilities.LASER_RECEPTOR_CAPABILITY.cast(this);
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLogicAdapter.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLogicAdapter.java
@@ -4,12 +4,10 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.TileNetworkList;
 import mekanism.common.integration.computer.IComputerIntegration;
-import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class TileEntityReactorLogicAdapter extends TileEntityReactorBlock implements IComputerIntegration {
@@ -181,12 +179,6 @@ public class TileEntityReactorLogicAdapter extends TileEntityReactorBlock implem
             default:
                 throw new NoSuchMethodException();
         }
-    }
-
-    @Nonnull
-    @Override
-    public int[] getSlotsForFace(@Nonnull EnumFacing side) {
-        return InventoryUtils.EMPTY;
     }
 
     public enum ReactorLogic {

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -220,7 +220,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
         }
 
         if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-            return (T) new FluidHandlerWrapper(this, side);
+            return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
         }
 
         return super.getCapability(capability, side);

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -13,7 +13,6 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTankInfo;
 import mekanism.api.gas.IGasHandler;
-import mekanism.api.gas.ITubeConnection;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismFluids;
 import mekanism.common.base.FluidHandlerWrapper;
@@ -47,7 +46,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityReactorPort extends TileEntityReactorBlock implements IFluidHandlerWrapper, IGasHandler,
-      ITubeConnection, IHeatTransfer, IConfigurable {
+      IHeatTransfer, IConfigurable {
 
     public boolean fluidEject;
 
@@ -200,14 +199,11 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     }
 
     @Override
-    public boolean canTubeConnect(EnumFacing side) {
-        return getReactor() != null;
-    }
-
-    @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (isCapabilityDisabled(capability, side)) {
+            return false;
+        }
         return capability == Capabilities.GAS_HANDLER_CAPABILITY
-              || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
               || capability == Capabilities.HEAT_TRANSFER_CAPABILITY
               || capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY
               || capability == Capabilities.CONFIGURABLE_CAPABILITY || super.hasCapability(capability, side);
@@ -215,8 +211,10 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 
     @Override
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
-        if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.TUBE_CONNECTION_CAPABILITY
-              || capability == Capabilities.HEAT_TRANSFER_CAPABILITY
+        if (isCapabilityDisabled(capability, side)) {
+            return null;
+        }
+        if (capability == Capabilities.GAS_HANDLER_CAPABILITY || capability == Capabilities.HEAT_TRANSFER_CAPABILITY
               || capability == Capabilities.CONFIGURABLE_CAPABILITY) {
             return (T) this;
         }
@@ -369,6 +367,8 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             //Allow inserting
             return false;
+        } else if (capability == Capabilities.GAS_HANDLER_CAPABILITY) {
+            return getReactor() == null;
         }
         return super.isCapabilityDisabled(capability, side);
     }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -37,6 +37,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
@@ -430,5 +431,15 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     @Override
     public EnumActionResult onRightClick(EntityPlayer player, EnumFacing side) {
         return EnumActionResult.PASS;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        //TODO: Decide if we want the port to be able to accept Hohlraum as well as the controller
+        if (isStrictEnergy(capability)|| capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
+            //Allow interacting with power given it is disabled in TileEntityReactorBlock
+            return false;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -44,6 +44,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityReactorPort extends TileEntityReactorBlock implements IFluidHandlerWrapper, IGasHandler,
       ITubeConnection, IHeatTransfer, IConfigurable {
@@ -361,6 +362,15 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return getReactor() != null && getReactor().isFormed() ? new int[]{0} : InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            //Allow inserting
+            return false;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -37,7 +37,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
@@ -431,15 +430,5 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     @Override
     public EnumActionResult onRightClick(EntityPlayer player, EnumFacing side) {
         return EnumActionResult.PASS;
-    }
-
-    @Override
-    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
-        //TODO: Decide if we want the port to be able to accept Hohlraum as well as the controller
-        if (isStrictEnergy(capability)|| capability == CapabilityEnergy.ENERGY || isTesla(capability, side)) {
-            //Allow interacting with power given it is disabled in TileEntityReactorBlock
-            return false;
-        }
-        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -27,7 +27,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 
 public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTurbineData> implements
       IStrictEnergyStorage {
@@ -253,5 +255,13 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTu
     @Override
     public int[] getSlotsForFace(@Nonnull EnumFacing side) {
         return InventoryUtils.EMPTY;
+    }
+
+    @Override
+    public boolean isCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side) {
+        if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            return true;
+        }
+        return super.isCapabilityDisabled(capability, side);
     }
 }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -423,7 +423,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
             }
 
             if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-                return (T) new FluidHandlerWrapper(this, side);
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
             }
 
             if (capability == Capabilities.TESLA_HOLDER_CAPABILITY
@@ -432,7 +432,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
             }
 
             if (capability == CapabilityEnergy.ENERGY) {
-                return (T) forgeEnergyManager.getWrapper(this, facing);
+                return CapabilityEnergy.ENERGY.cast(forgeEnergyManager.getWrapper(this, facing));
             }
         }
 

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -98,7 +98,7 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     public <T> T getCapability(@Nonnull Capability<T> capability, EnumFacing side) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
             if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
-                return (T) new FluidHandlerWrapper(this, side);
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(new FluidHandlerWrapper(this, side));
             }
         }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Have returned capabilities for a block's side obey the machine's configuration
- Support for "OffsetCapabilities". This system is used by the Digital Miner and the Advanced Bounding Blocks, to make it so that energy cables and item cables can only connect to the proper and marked spots on the miner.
- Makes it a lot easier to disable specific capabilities for a Tile Entity
  - ~Bins now use this to disable their sides from being interacted with instead of having special connection handling~
  - Power accepting tiles only expose the capability on a side that they can receive/give power
  - Multiblocks don't expose the item capability as "randomly" such as it is no longer possible  to just connect a logistical transporter to a reactor casing.

I believe with the way that this allows for removing the `TUBE_CONNECTION_CAPABILITY` all together/simplifying things down to not require having methods like `canTubeConnect` as I believe the reason there were to different capabilities in the first place was so that it can check if it really should have that capability.

Edit: Bins are now able to be interacted with from all sides using logistical transporters.
Edit 2:
Removed a bunch of unchecked cast warnings when it comes to Capabilities, and more importantly removed the need for `TUBE_CONNECTION_CAPABILITY` and use toggleable capabilities instead to only have the `GAS_HANDLER_CAPABILITY` available on some sides. This allows for cleaner implementation of addons wishing to support gas for their machines. On the same note things that previously only implemented/exposed the `ITubeConnection` now support `IGasHandler` so things like the Chemical Oxidizer will work with addons like gas conduits. While nothing relies on or uses `ITubeConnection` or `TUBE_CONNECTION_CAPABILITY` they are still in the code just deprecated so they do not break compat with addons that assume they exist/check for them.