### PR TITLE
Fixes IC2 complaining about unregistering without registering

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -105,8 +105,9 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             IEnergyTile registered = EnergyNet.instance.getTile(world, getPos());
 
             if (registered != this) {
-                if (registered != null) {
+                if (registered != null && ic2Registered) {
                     MinecraftForge.EVENT_BUS.post(new EnergyTileUnloadEvent(registered));
+                    ic2Registered = false;
                 } else {
                     MinecraftForge.EVENT_BUS.post(new EnergyTileLoadEvent(this));
                     ic2Registered = true;
@@ -120,8 +121,9 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
         if (!world.isRemote) {
             IEnergyTile registered = EnergyNet.instance.getTile(world, getPos());
 
-            if (registered != null) {
+            if (registered != null && ic2Registered) {
                 MinecraftForge.EVENT_BUS.post(new EnergyTileUnloadEvent(registered));
+                ic2Registered = false;
             }
         }
     }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -90,8 +90,9 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
             IEnergyTile registered = EnergyNet.instance.getTile(world, getPos());
 
             if (registered != this) {
-                if (registered != null) {
+                if (registered != null && ic2Registered) {
                     MinecraftForge.EVENT_BUS.post(new EnergyTileUnloadEvent(registered));
+                    ic2Registered = false;
                 } else {
                     MinecraftForge.EVENT_BUS.post(new EnergyTileLoadEvent(this));
                     ic2Registered = true;
@@ -105,8 +106,9 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
         if (!world.isRemote) {
             IEnergyTile registered = EnergyNet.instance.getTile(world, getPos());
 
-            if (registered != null) {
+            if (registered != null && ic2Registered) {
                 MinecraftForge.EVENT_BUS.post(new EnergyTileUnloadEvent(registered));
+                ic2Registered = false;
             }
         }
     }


### PR DESCRIPTION
## Changes proposed in this pull request:

Similar to https://github.com/mekanism-mod/Mekanism/issues/4974 but never got fully implemented in TileEntityInductionPort or TileEntityTurbineValve.

Only call the unregister, if it is actually registered.