### PR TITLE
Obsidian dust added as crushing recipe, Fixed other bugs related to obsidian dust

### DIFF
--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -358,7 +358,7 @@ public class Mekanism {
             RecipeHandler
                   .addEnrichmentChamberRecipe(new ItemStack(Blocks.REDSTONE_ORE), new ItemStack(Items.REDSTONE, 12));
             RecipeHandler.addEnrichmentChamberRecipe(new ItemStack(Blocks.OBSIDIAN),
-                  new ItemStack(MekanismItems.OtherDust, 2, 6));
+                  new ItemStack(MekanismItems.OtherDust, 4, 6));
             RecipeHandler.addEnrichmentChamberRecipe(new ItemStack(Items.COAL, 1, 0),
                   new ItemStack(MekanismItems.CompressedCarbon));
             RecipeHandler.addEnrichmentChamberRecipe(new ItemStack(Items.COAL, 1, 1),

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -76,7 +76,6 @@ public final class OreDictManager {
 
         for (ItemStack ore : OreDictionary.getOres("dustRefinedObsidian")) {
             RecipeHandler.addOsmiumCompressorRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.Ingot, 1, 0));
-            RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 1, 6));
             RecipeHandler
                   .addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.CompressedObsidian));
 
@@ -192,7 +191,7 @@ public final class OreDictManager {
         }
 
         for (ItemStack ore : OreDictionary.getOres("ingotRefinedObsidian")) {
-            RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 1, 6));
+            RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 1, 5));
         }
 
         for (ItemStack ore : OreDictionary.getOres("ingotOsmium")) {
@@ -272,11 +271,15 @@ public final class OreDictManager {
             RecipeHandler.addChemicalOxidizerRecipe(StackUtils.size(ore, 1), new GasStack(MekanismFluids.Lithium, 100));
         }
 
-        for (ItemStack ore : OreDictionary.getOres("dustObsidian")) {
+        for (ItemStack ore : OreDictionary.getOres("obsidian")) {
             RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 4), new ItemStack(Blocks.COBBLESTONE),
                   new ItemStack(Blocks.OBSIDIAN));
             RecipeHandler.addMetallurgicInfuserRecipe(InfuseRegistry.get("DIAMOND"), 10, StackUtils.size(ore, 1),
                   new ItemStack(MekanismItems.OtherDust, 1, 5));
+        }
+
+        for (ItemStack ore : OreDictionary.getOres("obsidian")) {
+            RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 4, 6));
         }
 
         for (ItemStack ore : OreDictionary.getOres("dustDiamond")) {

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -271,15 +271,11 @@ public final class OreDictManager {
             RecipeHandler.addChemicalOxidizerRecipe(StackUtils.size(ore, 1), new GasStack(MekanismFluids.Lithium, 100));
         }
 
-        for (ItemStack ore : OreDictionary.getOres("obsidian")) {
+        for (ItemStack ore : OreDictionary.getOres("dustObsidian")) {
             RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 4), new ItemStack(Blocks.COBBLESTONE),
                   new ItemStack(Blocks.OBSIDIAN));
             RecipeHandler.addMetallurgicInfuserRecipe(InfuseRegistry.get("DIAMOND"), 10, StackUtils.size(ore, 1),
                   new ItemStack(MekanismItems.OtherDust, 1, 5));
-        }
-
-        for (ItemStack ore : OreDictionary.getOres("obsidian")) {
-            RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 4, 6));
         }
 
         for (ItemStack ore : OreDictionary.getOres("dustDiamond")) {


### PR DESCRIPTION
Crushing machines now output 4 obsidian dust from 1 obsidian.

Fixed bug that made refined obsidian output regular obsidian dust when crushed.

~~Obsidian still gets caught in the ore batching that we use in order to provide recipes for the enrichment chamber. Will need to address this at a later date.~~ 
Corrected by Thiakil that this is not the case.

